### PR TITLE
Add Turbinia and Timesketch Load Balancer IPV6 support

### DIFF
--- a/charts/timesketch/README.md
+++ b/charts/timesketch/README.md
@@ -131,26 +131,27 @@ kubectl delete pvc -l release=timesketch-release
 
 ### Common Parameters
 
-| Name                              | Description                                                                                       | Value               |
-| --------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------- |
-| `nameOverride`                    | String to partially override names.fullname                                                       | `""`                |
-| `fullnameOverride`                | String to fully override names.fullname                                                           | `""`                |
-| `serviceAccount.create`           | Specifies whether a service account should be created                                             | `true`              |
-| `serviceAccount.annotations`      | Annotations to add to the service account                                                         | `{}`                |
-| `serviceAccount.name`             | The name of the service account to use                                                            | `timesketch`        |
-| `service.type`                    | Timesketch service type                                                                           | `ClusterIP`         |
-| `service.port`                    | Timesketch service port                                                                           | `5000`              |
-| `metrics.enabled`                 | Enables metrics scraping                                                                          | `true`              |
-| `metrics.port`                    | Port to scrape metrics from                                                                       | `9200`              |
-| `persistence.name`                | Timesketch persistent volume name                                                                 | `timesketchvolume`  |
-| `persistence.size`                | Timesketch persistent volume size                                                                 | `8Gi`               |
-| `persistence.storageClass`        | PVC Storage Class for Timesketch volume                                                           | `""`                |
-| `persistence.accessModes`         | PVC Access Mode for Timesketch volume                                                             | `["ReadWriteOnce"]` |
-| `ingress.enabled`                 | Enable the Timesketch loadbalancer for external access                                            | `false`             |
-| `ingress.host`                    | Domain name Timesketch will be hosted under                                                       | `""`                |
-| `ingress.className`               | IngressClass that will be be used to implement the Ingress                                        | `gce`               |
-| `ingress.gcp.managedCertificates` | Enables GCP managed certificates for your domain                                                  | `false`             |
-| `ingress.gcp.staticIPName`        | Name of the static IP address you reserved in GCP. Required when using "gce" in ingress.className | `""`                |
+| Name                              | Description                                                                                                                        | Value               |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `nameOverride`                    | String to partially override names.fullname                                                                                        | `""`                |
+| `fullnameOverride`                | String to fully override names.fullname                                                                                            | `""`                |
+| `serviceAccount.create`           | Specifies whether a service account should be created                                                                              | `true`              |
+| `serviceAccount.annotations`      | Annotations to add to the service account                                                                                          | `{}`                |
+| `serviceAccount.name`             | The name of the service account to use                                                                                             | `timesketch`        |
+| `service.type`                    | Timesketch service type                                                                                                            | `ClusterIP`         |
+| `service.port`                    | Timesketch service port                                                                                                            | `5000`              |
+| `metrics.enabled`                 | Enables metrics scraping                                                                                                           | `true`              |
+| `metrics.port`                    | Port to scrape metrics from                                                                                                        | `9200`              |
+| `persistence.name`                | Timesketch persistent volume name                                                                                                  | `timesketchvolume`  |
+| `persistence.size`                | Timesketch persistent volume size                                                                                                  | `8Gi`               |
+| `persistence.storageClass`        | PVC Storage Class for Timesketch volume                                                                                            | `""`                |
+| `persistence.accessModes`         | PVC Access Mode for Timesketch volume                                                                                              | `["ReadWriteOnce"]` |
+| `ingress.enabled`                 | Enable the Timesketch loadbalancer for external access                                                                             | `false`             |
+| `ingress.host`                    | Domain name Timesketch will be hosted under                                                                                        | `""`                |
+| `ingress.className`               | IngressClass that will be be used to implement the Ingress                                                                         | `gce`               |
+| `ingress.gcp.managedCertificates` | Enables GCP managed certificates for your domain                                                                                   | `false`             |
+| `ingress.gcp.staticIPName`        | Name of the static IP address you reserved in GCP. Required when using "gce" in ingress.className                                  | `""`                |
+| `ingress.gcp.staticIPV6Name`      | Name of the static IPV6 address you reserved in GCP. This can be optionally provided to deploy a loadbalancer with an IPV6 address | `""`                |
 
 ### Third Party Configuration
 

--- a/charts/timesketch/templates/ingress.yaml
+++ b/charts/timesketch/templates/ingress.yaml
@@ -37,3 +37,39 @@ spec:
       port:
         number: {{ .Values.service.port }} # Should match the port used by the Service
 {{- end }}
+{{- if and .Values.ingress.enabled .Values.ingress.gcp.staticIPV6Name }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name:  {{ include "timesketch.fullname" . }}-ingress-ipv6
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "timesketch.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.className }}
+    {{- if .Values.ingress.gcp.managedCertificates }}
+    networking.gke.io/managed-certificates: {{ include "timesketch.fullname" . }}-managed-ssl
+    {{- end }}
+    {{- if (eq .Values.ingress.className "gce") }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gcp.staticIPV6Name }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ include "timesketch.fullname" . }}-frontend-config
+    {{- end }}
+spec:
+  rules:
+    - host: {{ required "A valid .Values.ingress.host entry is required!" .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "timesketch.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+  defaultBackend:
+    service:
+      name: {{ include "timesketch.fullname" . }} # Name of the Service targeted by the Ingress
+      port:
+        number: {{ .Values.service.port }} # Should match the port used by the Service
+{{- end }}

--- a/charts/timesketch/values.yaml
+++ b/charts/timesketch/values.yaml
@@ -237,6 +237,10 @@ ingress:
     ## ref https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
     ##
     staticIPName: ""
+    ## @param ingress.gcp.staticIPV6Name Name of the static IPV6 address you reserved in GCP. This can be optionally provided to deploy a loadbalancer with an IPV6 address
+    ## ref https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+    ##
+    staticIPV6Name: ""
 ## @section Third Party Configuration
 ## This section contains all the main configuration for third party dependencies
 ## Timesketch requires to run

--- a/charts/turbinia/README.md
+++ b/charts/turbinia/README.md
@@ -212,6 +212,7 @@ kubectl delete pvc -l release=turbinia-release
 | `ingress.className`               | IngressClass that will be be used to implement the Ingress                                                                                                                                                           | `gce`                                                                                        |
 | `ingress.gcp.managedCertificates` | Enabled GCP managed certificates for your domain                                                                                                                                                                     | `false`                                                                                      |
 | `ingress.gcp.staticIPName`        | Name of the static IP address you reserved in GCP                                                                                                                                                                    | `""`                                                                                         |
+| `ingress.gcp.staticIPV6Name`      | Name of the static IPV6 address you reserved in GCP. This can be optionally provided to deploy a loadbalancer with an IPV6 address                                                                                   | `""`                                                                                         |
 
 ### Third Party Configuration
 

--- a/charts/turbinia/templates/ingress.yaml
+++ b/charts/turbinia/templates/ingress.yaml
@@ -37,3 +37,39 @@ spec:
       port:
         number: {{ .Values.oauth2proxy.service.port }} # Should match the port used by the Service
 {{- end }}
+{{- if and .Values.ingress.enabled .Values.ingress.gcp.staticIPV6Name }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name:  {{ include "turbinia.fullname" . }}-ingress-ipv6
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "turbinia.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.className }}
+    {{- if .Values.ingress.gcp.managedCertificates }}
+    networking.gke.io/managed-certificates: {{ include "turbinia.fullname" . }}-managed-ssl
+    {{- end }}
+    {{- if (eq .Values.ingress.className "gce") }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gcp.staticIPV6Name }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ include "turbinia.fullname" . }}-frontend-config
+    {{- end }}
+spec:
+  rules:
+    - host: {{ required "A valid .Values.ingress.host entry is required!" .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-oauth2proxy
+                port:
+                  number: {{ .Values.oauth2proxy.service.port }}
+  defaultBackend:
+    service:
+      name: {{ .Release.Name }}-oauth2proxy # Name of the Service targeted by the Ingress
+      port:
+        number: {{ .Values.oauth2proxy.service.port }} # Should match the port used by the Service
+{{- end }}

--- a/charts/turbinia/values.yaml
+++ b/charts/turbinia/values.yaml
@@ -412,13 +412,13 @@ persistence:
 ingress:
   ## @param ingress.enabled Enable the Turbinia loadbalancer for external access
   ##
-  enabled: false
+  enabled: true
   ## @param ingress.host The domain name Turbinia will be hosted under
   ## Please ensure this value is set when enabling Ingress. If using "gce" for
   ## ingress.className, please ensure you have a DNS record set for the IP address
   ## registered under ingress.gcp.staticIPName
   ##
-  host: ""
+  host: "turb.com"
   ## @param ingress.className IngressClass that will be be used to implement the Ingress
   ## ref https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/
   ##
@@ -434,7 +434,11 @@ ingress:
     ## This is required when using "gce" in ingress.className
     ## ref https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
     ##
-    staticIPName: ""
+    staticIPName: "test"
+    ## @param ingress.gcp.staticIPV6Name Name of the static IPV6 address you reserved in GCP. This can be optionally provided to deploy a loadbalancer with an IPV6 address
+    ## ref https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+    ##
+    staticIPV6Name: ""
 ## @section Third Party Configuration
 ##
 ## @section Redis configuration parameters

--- a/charts/turbinia/values.yaml
+++ b/charts/turbinia/values.yaml
@@ -412,13 +412,13 @@ persistence:
 ingress:
   ## @param ingress.enabled Enable the Turbinia loadbalancer for external access
   ##
-  enabled: true
+  enabled: false
   ## @param ingress.host The domain name Turbinia will be hosted under
   ## Please ensure this value is set when enabling Ingress. If using "gce" for
   ## ingress.className, please ensure you have a DNS record set for the IP address
   ## registered under ingress.gcp.staticIPName
   ##
-  host: "turb.com"
+  host: ""
   ## @param ingress.className IngressClass that will be be used to implement the Ingress
   ## ref https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/
   ##
@@ -434,7 +434,7 @@ ingress:
     ## This is required when using "gce" in ingress.className
     ## ref https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
     ##
-    staticIPName: "test"
+    staticIPName: ""
     ## @param ingress.gcp.staticIPV6Name Name of the static IPV6 address you reserved in GCP. This can be optionally provided to deploy a loadbalancer with an IPV6 address
     ## ref https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
     ##


### PR DESCRIPTION
Optionally deploy an additional loadbalancer with IPV6. Closes #4 