### PR TITLE
Reduce default Redis memory to below limit

### DIFF
--- a/charts/turbinia/values-production.yaml
+++ b/charts/turbinia/values-production.yaml
@@ -350,7 +350,7 @@ redis:
     resources:
       requests:
         cpu: 4000m
-        memory: 500Gi
+        memory: 8Gi
       limits:
         cpu: 8000m
         memory: 16Gi


### PR DESCRIPTION
Default redis memory request changed from 500Gi -> 8Gi