### PR TITLE
Turbinia load balancer update

### DIFF
--- a/charts/turbinia/README.md
+++ b/charts/turbinia/README.md
@@ -80,6 +80,10 @@ helm upgrade turbinia-prod \
     --set oauth2proxy.service.annotations."cloud\.google\.com/backend-config=\{\"ports\": \{\"4180\": \"\{\{ .Release.Name \}\}-oauth2-backend-config\"\}\}"
 ```
 
+> **Warning**: Turbinia relies on the Oauth2 Proxy for authentication. If you
+plan to expose Turbinia with a public facing IP, it is highly recommended that
+the Oauth2 Proxy is deployed alongside with the command provided above.
+
 ## Uninstalling the Chart
 
 To uninstall/delete a Helm deployment with a release name of `turbinia-release`:

--- a/charts/turbinia/templates/ingress.yaml
+++ b/charts/turbinia/templates/ingress.yaml
@@ -27,15 +27,26 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              service:
+                {{- if .Values.oauth2proxy.enabled }}
                 name: {{ .Release.Name }}-oauth2proxy
                 port:
                   number: {{ .Values.oauth2proxy.service.port }}
+                {{- else }}
+                name: {{ include "turbinia.fullname" . }}-api
+                port:
+                  number: {{ .Values.service.port }}
+                {{- end }}
   defaultBackend:
     service:
+      {{- if .Values.oauth2proxy.enabled }} 
       name: {{ .Release.Name }}-oauth2proxy # Name of the Service targeted by the Ingress
       port:
         number: {{ .Values.oauth2proxy.service.port }} # Should match the port used by the Service
+      {{- else }}
+      name: {{ include "turbinia.fullname" . }}-api
+      port:
+        number: {{ .Values.service.port }}
+      {{- end }}
 {{- end }}
 {{- if and .Values.ingress.enabled .Values.ingress.gcp.staticIPV6Name }}
 ---
@@ -73,14 +84,14 @@ spec:
                   number: {{ .Values.service.port }}
                 {{- end }}
   defaultBackend:
-    {{- if .Values.oauth2proxy.enabled }}
     service:
+      {{- if .Values.oauth2proxy.enabled }} 
       name: {{ .Release.Name }}-oauth2proxy # Name of the Service targeted by the Ingress
       port:
         number: {{ .Values.oauth2proxy.service.port }} # Should match the port used by the Service
-    {{- else }}
-    name: {{ include "turbinia.fullname" . }}-api
-    port:
-      number: {{ .Values.service.port }}
-    {{- end }}
+      {{- else }}
+      name: {{ include "turbinia.fullname" . }}-api
+      port:
+        number: {{ .Values.service.port }}
+      {{- end }}
 {{- end }}

--- a/charts/turbinia/templates/ingress.yaml
+++ b/charts/turbinia/templates/ingress.yaml
@@ -27,6 +27,7 @@ spec:
           - path: /
             pathType: Prefix
             backend:
+              service:
                 {{- if .Values.oauth2proxy.enabled }}
                 name: {{ .Release.Name }}-oauth2proxy
                 port:
@@ -74,6 +75,7 @@ spec:
           - path: /
             pathType: Prefix
             backend:
+              service:
                 {{- if .Values.oauth2proxy.enabled }}
                 name: {{ .Release.Name }}-oauth2proxy
                 port:

--- a/charts/turbinia/templates/ingress.yaml
+++ b/charts/turbinia/templates/ingress.yaml
@@ -63,13 +63,24 @@ spec:
           - path: /
             pathType: Prefix
             backend:
-              service:
+                {{- if .Values.oauth2proxy.enabled }}
                 name: {{ .Release.Name }}-oauth2proxy
                 port:
                   number: {{ .Values.oauth2proxy.service.port }}
+                {{- else }}
+                name: {{ include "turbinia.fullname" . }}-api
+                port:
+                  number: {{ .Values.service.port }}
+                {{- end }}
   defaultBackend:
+    {{- if .Values.oauth2proxy.enabled }}
     service:
       name: {{ .Release.Name }}-oauth2proxy # Name of the Service targeted by the Ingress
       port:
         number: {{ .Values.oauth2proxy.service.port }} # Should match the port used by the Service
+    {{- else }}
+    name: {{ include "turbinia.fullname" . }}-api
+    port:
+      number: {{ .Values.service.port }}
+    {{- end }}
 {{- end }}

--- a/charts/turbinia/templates/ingress.yaml
+++ b/charts/turbinia/templates/ingress.yaml
@@ -33,7 +33,7 @@ spec:
                 port:
                   number: {{ .Values.oauth2proxy.service.port }}
                 {{- else }}
-                name: {{ include "turbinia.fullname" . }}-api
+                name: {{ include "turbinia.fullname" . }}
                 port:
                   number: {{ .Values.service.port }}
                 {{- end }}
@@ -44,7 +44,7 @@ spec:
       port:
         number: {{ .Values.oauth2proxy.service.port }} # Should match the port used by the Service
       {{- else }}
-      name: {{ include "turbinia.fullname" . }}-api
+      name: {{ include "turbinia.fullname" . }}
       port:
         number: {{ .Values.service.port }}
       {{- end }}
@@ -81,7 +81,7 @@ spec:
                 port:
                   number: {{ .Values.oauth2proxy.service.port }}
                 {{- else }}
-                name: {{ include "turbinia.fullname" . }}-api
+                name: {{ include "turbinia.fullname" . }}
                 port:
                   number: {{ .Values.service.port }}
                 {{- end }}
@@ -92,7 +92,7 @@ spec:
       port:
         number: {{ .Values.oauth2proxy.service.port }} # Should match the port used by the Service
       {{- else }}
-      name: {{ include "turbinia.fullname" . }}-api
+      name: {{ include "turbinia.fullname" . }}
       port:
         number: {{ .Values.service.port }}
       {{- end }}


### PR DESCRIPTION
Updates the Turbinia load balancer to allow for the API server to be exposed without Oauth2 Proxy to allow for setups where another form of authentication is being used or is inside some VPN