### PR TITLE
Fix backendconfig with Turbinia Healthcheck

### DIFF
--- a/charts/turbinia/README.md
+++ b/charts/turbinia/README.md
@@ -77,7 +77,7 @@ helm upgrade turbinia-prod \
     --set oauth2proxy.configuration.redirectUrl=https://<DOMAIN>/oauth2/callback
     --set oauth2proxy.configuration.authenticatedEmailsFile.content=\{email1@domain.com, email2@domain.com\}
     --set oauth2proxy.service.annotations."cloud\.google\.com/neg=\{\"ingress\": true\}" \
-    --set oauth2proxy.service.annotations."cloud\.google\.com/backend-config=\{\"ports\": \{\"4180\": \"\{\{ .Release.Name \}\}-oauth2-backend-config\"\}\}"
+    --set oauth2proxy.service.annotations."cloud\.google\.com/backend-config=\{\"ports\": \{\"4180\": \"\{\{ .Release.Name \}\}-backend-config\"\}\}"
 ```
 
 > **Warning**: Turbinia relies on the Oauth2 Proxy for authentication. If you

--- a/charts/turbinia/templates/gcp/backendconfig.yaml
+++ b/charts/turbinia/templates/gcp/backendconfig.yaml
@@ -2,7 +2,7 @@
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
-  name: "{{ .Release.Name }}-oauth2-backend-config"
+  name: "{{ .Release.Name }}-backend-config"
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "turbinia.labels" . | nindent 4 }}
@@ -14,6 +14,11 @@ spec:
     healthyThreshold: 2
     unhealthyThreshold: 2
     type: HTTP
+    {{- if .Values.oauth2proxy.enabled }}
     requestPath: /ping
     port: 4180
+    {{- else }}
+    requestPath: /web
+    port: 8000
+    {{- end }}
 {{- end }}

--- a/charts/turbinia/templates/service.yaml
+++ b/charts/turbinia/templates/service.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-turbinia
+  {{- if and (.Values.ingress.enabled) (not .Values.oauth2proxy.enabled) }}
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"ports": {"8000": "{{ .Release.Name }}-backend-config"}}'
+  {{- end }}
   labels:
     {{- include "turbinia.labels" . | nindent 4 }}
 spec:

--- a/charts/turbinia/values.yaml
+++ b/charts/turbinia/values.yaml
@@ -553,7 +553,7 @@ oauth2proxy:
     ##
     annotations: {}
     #  cloud.google.com/neg: '{"ingress": true}'
-    #  cloud.google.com/backend-config: '{"ports": {"4180": "{{ .Release.Name }}-oauth2-backend-config"}}'
+    #  cloud.google.com/backend-config: '{"ports": {"4180": "{{ .Release.Name }}-backend-config"}}'
   ## Configuration section
   ##
   configuration:


### PR DESCRIPTION
Fixes GCP Network Endpoint backend config when you do not deploy the Oauth2 Proxy and just the API server itself, need to set annotations as well on the service to associate the backendconfig (GCP way of doing routing all through a private cluster) with the service and ingress.