### PR TITLE
Fix oauth2 proxy value reference

### DIFF
--- a/charts/osdfir-infrastructure/templates/NOTES.txt
+++ b/charts/osdfir-infrastructure/templates/NOTES.txt
@@ -31,7 +31,7 @@ Run the following commands on your workstation to orchestrate collection and pro
   $ poetry install && poetry shell
   $ dftimewolf -h
   $ If using Timesketch, use the credentials provided in this chart when prompted
-  {{- if .Values.oauth2proxy.enabled }}
+  {{ if .Values.turbinia.oauth2proxy.enabled -}}
   $ If using Turbinia with the Oauth2 Proxy, use the command below to generate the necessary config
     $ kubectl get secret --namespace {{ .Release.Namespace }} {{ include "turbinia.fullname" . }}-secret -o jsonpath="{.data.turbinia-secret}" | base64 -d > ~/.dftimewolf_turbinia_secrets.json
   {{- end }}


### PR DESCRIPTION
Quick fix for the below (have not pushed the new charts yet so not bumping chart versions)
```
helm install os ../osdfir-infrastructure/
Error: INSTALLATION FAILED: template: osdfir-infrastructure/templates/NOTES.txt:34:15: executing "osdfir-infrastructure/templates/NOTES.txt" at <.Values.oauth2proxy.enabled>: nil pointer evaluating interface {}.enabled
```

