### PR TITLE
[charts/turbinia] Fix typo in turbinia controller config mount name

### DIFF
--- a/charts/turbinia/templates/controller-deployment.yaml
+++ b/charts/turbinia/templates/controller-deployment.yaml
@@ -60,7 +60,7 @@ spec:
             - mountPath: /mnt/turbiniavolume
               name: turbiniavolume
             - mountPath: /etc/turbinia
-              name: turinia-configs
+              name: turbinia-configs
           ports:
             {{- if .Values.metrics.enabled }}
             - containerPort: {{ .Values.metrics.port }}


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

<!-- Describe what the change does. -->

Fixes a typo in the non-gcp version of turbinia controller's deployment that causes the deployment to fail (```Deployment.apps "osdfir-infrastructure-turbinia-controller" is invalid: spec.template.spec.containers[0].volumeMounts[1].name: Not found: "turinia-configs"```)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [charts/<name_of_the_chart>] Descriptive title
