### PR TITLE
Automated Github Chart releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

Adds automated releasing for the Helm charts through GH Pages.  More details on how this works can be found [here](https://github.com/helm/chart-releaser-action) and [here](https://helm.sh/docs/howto/chart_releaser_action/).

The proposition is to move away from OCI to instead use GH Pages/GH actions releaser for its ease
 
Installing charts would look something like (will update docs at a later PR):

```
helm repo add osdfir-infrastructure (or any alias name) https://google.github.io/osdfir-infrastructure
helm install osdfir-infrastructure/osdfir-infrastructure
helm install osdfir-infrastructure/timesketch
helm install osdfir-infrastructure/turbinia
```

Anytime we merge something in main and the Chart version for any of the charts have been updated, the GH action will automatically create a new release and push to the GH Page.
