### PR TITLE
Adding dfDewey values to OSDFIR and Turbinia charts

### DIFF
--- a/charts/osdfir-infrastructure/values.yaml
+++ b/charts/osdfir-infrastructure/values.yaml
@@ -25,6 +25,10 @@ global:
     ## @param global.turbinia.servicePort Turbinia API service port (overrides `turbinia.service.port`)
     ##
     servicePort: 8000
+  dfdewey:
+    ## @param global.dfdewey.enabled Enables the dfDewey deployment along with Turbinia
+    ##
+    enabled: false
   yeti:
     ## @param global.yeti.enabled Enables the Yeti deployment (only used in the main OSDFIR Infrastructure Helm chart)
     ##

--- a/charts/turbinia/Chart.lock
+++ b/charts/turbinia/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: oauth2-proxy
   repository: https://charts.bitnami.com/bitnami
   version: 4.1.3
-digest: sha256:daa9ae8e7b125661b78c5ccd3edf45db91dea36bf79eb35e504f3e5d08d19fd2
-generated: "2023-09-19T23:20:07.675142702Z"
+- name: dfdewey
+  repository: https://google.github.io/osdfir-infrastructure/
+  version: 1.0.0
+digest: sha256:70d4b366b260d85953ec95b4ed1679acb995f1139813f940eec064b2183b5649
+generated: "2024-03-18T12:57:01.522970858+11:00"

--- a/charts/turbinia/Chart.yaml
+++ b/charts/turbinia/Chart.yaml
@@ -19,6 +19,10 @@ dependencies:
   alias: oauth2proxy
   version: 4.1.3
   repository: https://charts.bitnami.com/bitnami
+- condition: global.dfdewey.enabled
+  name: dfdewey
+  repository: https://google.github.io/osdfir-infrastructure/
+  version: 1.0.0
 maintainers:
   - name: Open Source DFIR
     email: osdfir-maintainers@googlegroups.com

--- a/charts/turbinia/templates/init-configmap.yaml
+++ b/charts/turbinia/templates/init-configmap.yaml
@@ -43,6 +43,12 @@ data:
     sed -i -e "s/^TURBINIA_ZONE = .*$/TURBINIA_ZONE = '{{ include "turbinia.gcp.zone" . }}'/g" turbinia.conf
     sed -i -e "s/^TURBINIA_REGION = .*$/TURBINIA_REGION = '{{ include "turbinia.gcp.region" . }}'/g" turbinia.conf
     {{- end }}
+
+    {{- if .Values.global.dfdewey.enabled }}
+    # Set up dfDewey config
+    sed -i -e "s/^DFDEWEY_PG_HOST = .*$/DFDEWEY_PG_HOST = \'{{- printf "%s-%s" .Release.Name .Values.dfdewey.postgresql.nameOverride -}}\'/g" turbinia.conf
+    sed -i -e "s/^DFDEWEY_OS_HOST = .*$/DFDEWEY_OS_HOST = \'{{ .Values.dfdewey.opensearch.masterService }}\'/g" turbinia.conf
+    {{- end}}
     
     # Setup logging, mount, and output paths
     sed -i -e "s/^SHARED_FILESYSTEM = .*$/SHARED_FILESYSTEM = True/g" turbinia.conf

--- a/charts/turbinia/values-production.yaml
+++ b/charts/turbinia/values-production.yaml
@@ -314,6 +314,118 @@ persistence:
   ## 
   accessModes:
     - ReadWriteMany
+## Turbinia dfDewey parameters
+##
+dfdewey:
+  postgresql:
+    ## @param dfdewey.postgresql.enabled Enables the Postgresql deployment
+    ##
+    enabled: true
+    ## @param dfdewey.postgresql.nameOverride String to partially override common.names.fullname template
+    ##
+    nameOverride: dfdewey-postgresql
+    ## PostgreSQL Authentication parameters
+    ##
+    auth:
+      ## @param dfdewey.postgresql.auth.username Name for a custom user to create
+      ##
+      username: "dfdewey"
+      ## @param dfdewey.postgresql.auth.password Password for the custom user to create. Ignored if auth.existingSecret is provided
+      ##
+      password: "password"
+      ## @param dfdewey.postgresql.auth.database Name for a custom database to create
+      ##
+      database: "dfdewey"
+    ## PostgreSQL Primary configuration parameters
+    ##
+    primary:
+      ## PostgreSQL Primary persistence configuration
+      ##
+      persistence:
+        ## @param dfdewey.postgresql.primary.persistence.size PostgreSQL Persistent Volume size
+        ##
+        size: 500Gi
+      ## PostgreSQL Primary resource requests and limits
+      ## @param dfdewey.postgresql.primary.resources.requests.cpu Requested cpu for the PostgreSQL Primary containers
+      ## @param dfdewey.postgresql.primary.resources.requests.memory Requested memory for the PostgreSQL Primary containers
+      ## @param dfdewey.postgresql.primary.resources.limits Resource limits for the PostgreSQL Primary containers
+      ##
+      resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits: {}
+  ## @section Opensearch Configuration Parameters
+  ## IMPORTANT: The Opensearch Security Plugin / TLS has not yet been configured by default
+  ## ref on steps required https://opensearch.org/docs/1.1/security-plugin/configuration/index/
+  ##
+  opensearch:
+    ## @param dfdewey.opensearch.enabled Enables the Opensearch deployment
+    ##
+    enabled: true
+    ## @param dfdewey.opensearch.nameOverride Overrides the clusterName when used in the naming of resources
+    ##
+    nameOverride: dfdewey-opensearch
+    ## @param dfdewey.opensearch.masterService The service name used to connect to the masters
+    ##
+    masterService: dfdewey-opensearch
+    ## @param dfdewey.opensearch.singleNode Replicas will be forced to 1
+    ##
+    singleNode: true
+    ## @param dfdewey.opensearch.sysctlInit.enabled Sets optimal sysctl's through privileged initContainer
+    ##
+    sysctlInit:
+      enabled: true
+    ## @param dfdewey.opensearch.opensearchJavaOpts Sets the size of the Opensearch Java heap
+    ## It is recommended to use at least half the system's available ram
+    ##
+    opensearchJavaOpts: "-Xms32g -Xmx32g"
+    ## @param dfdewey.opensearch.config.opensearch.yml Opensearch configuration file. Can be appended for additional configuration options
+    ## Values must be YAML literal style scalar / YAML multiline string
+    ## <filename>: |
+    ##   <formatted-value(s)>
+    ##
+    config:
+      opensearch.yml: |
+        discovery:
+          type: single-node
+        plugins:
+          security:
+            disabled: true
+    extraEnvs:
+    ## @param dfdewey.opensearch.extraEnvs[0].name Environment variable to set the initial admin password
+    ##
+    - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+    ## @param dfdewey.opensearch.extraEnvs[0].value The initial admin password
+    ##
+      value: KyfwJExU2!2MvU6j
+    ## @param dfdewey.opensearch.extraEnvs[1].name Environment variable to disable Opensearch Demo config
+    ##
+    - name: DISABLE_INSTALL_DEMO_CONFIG
+    ## @param dfdewey.opensearch.extraEnvs[1].value Disables Opensearch Demo config
+    ##
+      value: "true"
+    ## @param dfdewey.opensearch.extraEnvs[2].name Environment variable to disable Opensearch Security plugin given that
+    ## certificates were not setup as part of this deployment
+    ##
+    - name: DISABLE_SECURITY_PLUGIN
+    ## @param dfdewey.opensearch.extraEnvs[2].value Disables Opensearch Security plugin
+    ##
+      value: "true"
+    ## Opensearch persistence configuration
+    ##
+    persistence:
+      ## @param dfdewey.opensearch.persistence.size Opensearch Persistent Volume size. A persistent volume would be created for each Opensearch replica running
+      ##
+      size: 6Ti
+    ## Opensearch resource requests
+    ## @param dfdewey.opensearch.resources.requests.cpu Requested cpu for the Opensearch containers
+    ## @param dfdewey.opensearch.resources.requests.memory Requested memory for the Opensearch containers
+    ##
+    resources:
+      requests:
+        cpu: 8000m
+        memory: 32Gi
 ## @section Third Party Configuration
 ##
 ## @section Redis configuration parameters

--- a/charts/turbinia/values.yaml
+++ b/charts/turbinia/values.yaml
@@ -21,6 +21,10 @@ global:
     ## @param global.turbinia.servicePort Turbinia API service port (overrides `turbinia.service.port`)
     ##
     servicePort:
+  dfdewey:
+    ## @param global.dfdewey.enabled Enables the dfDewey deployment along with Turbinia
+    ##
+    enabled: false
   yeti:
     ## @param global.yeti.enabled Enables the Yeti deployment (only used in the main OSDFIR Infrastructure Helm chart)
     ##
@@ -458,6 +462,118 @@ ingress:
     ## ref https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
     ##
     staticIPV6Name: ""
+## Turbinia dfDewey parameters
+##
+dfdewey:
+  postgresql:
+    ## @param dfdewey.postgresql.enabled Enables the Postgresql deployment
+    ##
+    enabled: true
+    ## @param dfdewey.postgresql.nameOverride String to partially override common.names.fullname template
+    ##
+    nameOverride: dfdewey-postgresql
+    ## PostgreSQL Authentication parameters
+    ##
+    auth:
+      ## @param dfdewey.postgresql.auth.username Name for a custom user to create
+      ##
+      username: "dfdewey"
+      ## @param dfdewey.postgresql.auth.password Password for the custom user to create. Ignored if auth.existingSecret is provided
+      ##
+      password: "password"
+      ## @param dfdewey.postgresql.auth.database Name for a custom database to create
+      ##
+      database: "dfdewey"
+    ## PostgreSQL Primary configuration parameters
+    ##
+    primary:
+      ## PostgreSQL Primary persistence configuration
+      ##
+      persistence:
+        ## @param dfdewey.postgresql.primary.persistence.size PostgreSQL Persistent Volume size
+        ##
+        size: 8Gi
+      ## PostgreSQL Primary resource requests and limits
+      ## @param dfdewey.postgresql.primary.resources.requests.cpu Requested cpu for the PostgreSQL Primary containers
+      ## @param dfdewey.postgresql.primary.resources.requests.memory Requested memory for the PostgreSQL Primary containers
+      ## @param dfdewey.postgresql.primary.resources.limits Resource limits for the PostgreSQL Primary containers
+      ##
+      resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits: {}
+  ## @section Opensearch Configuration Parameters
+  ## IMPORTANT: The Opensearch Security Plugin / TLS has not yet been configured by default
+  ## ref on steps required https://opensearch.org/docs/1.1/security-plugin/configuration/index/
+  ##
+  opensearch:
+    ## @param dfdewey.opensearch.enabled Enables the Opensearch deployment
+    ##
+    enabled: true
+    ## @param dfdewey.opensearch.nameOverride Overrides the clusterName when used in the naming of resources
+    ##
+    nameOverride: dfdewey-opensearch
+    ## @param dfdewey.opensearch.masterService The service name used to connect to the masters
+    ##
+    masterService: dfdewey-opensearch
+    ## @param dfdewey.opensearch.singleNode Replicas will be forced to 1
+    ##
+    singleNode: true
+    ## @param dfdewey.opensearch.sysctlInit.enabled Sets optimal sysctl's through privileged initContainer
+    ##
+    sysctlInit:
+      enabled: true
+    ## @param dfdewey.opensearch.opensearchJavaOpts Sets the size of the Opensearch Java heap
+    ## It is recommended to use at least half the system's available ram
+    ##
+    opensearchJavaOpts: "-Xms512m -Xmx512m"
+    ## @param dfdewey.opensearch.config.opensearch.yml Opensearch configuration file. Can be appended for additional configuration options
+    ## Values must be YAML literal style scalar / YAML multiline string
+    ## <filename>: |
+    ##   <formatted-value(s)>
+    ##
+    config:
+      opensearch.yml: |
+        discovery:
+          type: single-node
+        plugins:
+          security:
+            disabled: true
+    extraEnvs:
+    ## @param dfdewey.opensearch.extraEnvs[0].name Environment variable to set the initial admin password
+    ##
+    - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+    ## @param dfdewey.opensearch.extraEnvs[0].value The initial admin password
+    ##
+      value: KyfwJExU2!2MvU6j
+    ## @param dfdewey.opensearch.extraEnvs[1].name Environment variable to disable Opensearch Demo config
+    ##
+    - name: DISABLE_INSTALL_DEMO_CONFIG
+    ## @param dfdewey.opensearch.extraEnvs[1].value Disables Opensearch Demo config
+    ##
+      value: "true"
+    ## @param dfdewey.opensearch.extraEnvs[2].name Environment variable to disable Opensearch Security plugin given that
+    ## certificates were not setup as part of this deployment
+    ##
+    - name: DISABLE_SECURITY_PLUGIN
+    ## @param dfdewey.opensearch.extraEnvs[2].value Disables Opensearch Security plugin
+    ##
+      value: "true"
+    ## Opensearch persistence configuration
+    ##
+    persistence:
+      ## @param dfdewey.opensearch.persistence.size Opensearch Persistent Volume size. A persistent volume would be created for each Opensearch replica running
+      ##
+      size: 2Gi
+    ## Opensearch resource requests
+    ## @param dfdewey.opensearch.resources.requests.cpu Requested cpu for the Opensearch containers
+    ## @param dfdewey.opensearch.resources.requests.memory Requested memory for the Opensearch containers
+    ##
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
 ## @section Third Party Configuration
 ##
 ## @section Redis configuration parameters


### PR DESCRIPTION
### Description of the change

Adding values for the dfDewey datastore Helm chart to the OSDFIR Infrastructure and Turbinia Helm charts.

### Applicable issues

- fixes #26 

### Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Newly added variables are documented in the values.yaml
- [X] Title of the pull request is descriptive
