### PR TITLE
charts/turbinia configuration fixes

### DIFF
--- a/charts/turbinia/Chart.yaml
+++ b/charts/turbinia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: turbinia
-version: 1.0.3
+version: 1.0.4
 description: A Helm chart for Turbinia Kubernetes deployments.
 keywords:
 - turbinia

--- a/charts/turbinia/templates/_initContainer.tpl
+++ b/charts/turbinia/templates/_initContainer.tpl
@@ -5,7 +5,7 @@ and Worker pod upon startup.
 */}}
 {{- define "turbinia.initContainer" -}}
 - name: init-turbinia
-  image: busybox
+  image: alpine
   command: ['sh', '-c', '/init/init-turbinia.sh']
   env:
     {{- if and .Values.redis.enabled .Values.redis.auth.enabled }}

--- a/charts/turbinia/templates/init-configmap.yaml
+++ b/charts/turbinia/templates/init-configmap.yaml
@@ -9,6 +9,7 @@ data:
   init-turbinia.sh: |
     #!/bin/sh
     set -e
+    apk add jq
 
     # Fix Filestore permissions
     chmod go+w /mnt/turbiniavolume
@@ -20,12 +21,18 @@ data:
     if [  $(ls /tmp/turbinia/ | wc -l) -gt 0 ]; then
       echo "Using exisiting configuration file provided."
       cp /tmp/turbinia/* /etc/turbinia/
-    else 
+    else
       # Pull default config if one is not already provided
-      echo -n "* Fetching configuration files.." 
-      # Fetch default Turbinia config file
+      {{- $turbiniaWorker := "us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker" -}}
+      {{- if eq .Values.worker.image.repository $turbiniaWorker }}
+      echo -n "* Fetching the release Turbinia configuration file..." 
+      RELEASE_TAG=$(wget -O- https://api.github.com/repos/google/turbinia/releases | jq -r '.[0] | .tag_name')
+      wget "https://raw.githubusercontent.com/google/turbinia/$RELEASE_TAG/turbinia/config/turbinia_config_tmpl.py" -O turbinia.conf
+      {{- else }}
+      echo -n "* Fetching the latest Turbinia configuration file..." 
       wget "https://raw.githubusercontent.com/google/turbinia/master/turbinia/config/turbinia_config_tmpl.py" -O turbinia.conf
       echo "OK"
+      {{- end }}
     fi
 
     # Set up the Redis connection
@@ -55,6 +62,7 @@ data:
     sed -i -e "s/^LOG_DIR = .*$/LOG_DIR = '\/mnt\/{{ .Values.persistence.name }}\/logs'/g" turbinia.conf
     sed -i -e "s/^MOUNT_DIR_PREFIX = .*$/MOUNT_DIR_PREFIX = '\/mnt\/turbinia'/g" turbinia.conf
     sed -i -e "s/^OUTPUT_DIR = .*$/OUTPUT_DIR = '\/mnt\/{{ .Values.persistence.name }}\/output'/g" turbinia.conf
+    sed -i -e "s/^API_EVIDENCE_UPLOAD_DIR = .*$/API_EVIDENCE_UPLOAD_DIR = '\/mnt\/{{ .Values.persistence.name }}\/upload'/g" turbinia.conf
     
     # Disable Turbinia Jobs
     sed -i -e "s/^DISABLED_JOBS = .*$/DISABLED_JOBS = {{ .Values.config.disabledJobs }}/g" turbinia.conf


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

<!-- Describe what the change does. -->

Differentiates which Turbinia config gets pulled (either the release version or master) by checking if the worker image repo matches indicating a release version and if not to pull the config from the master branch.

Also fixes an issue with `API_EVIDENCE_UPLOAD_DIR` being set to missing path 

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #132

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ X] Title of the pull request is descriptive
