### PR TITLE
Fix Timesketch reference to Yeti service and lock Yeti arangodb version

### DIFF
--- a/charts/timesketch/Chart.yaml
+++ b/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 1.0.1
+version: 1.0.2
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/timesketch/templates/init-configmap.yaml
+++ b/charts/timesketch/templates/init-configmap.yaml
@@ -52,5 +52,5 @@ data:
     # Yeti integration
     {{- if .Values.global.yeti.enabled }}
     sed -i 's#^YETI_API_KEY =.*#YETI_API_KEY = "'$YETI_API_KEY'"#' timesketch.conf
-    sed -i 's#^YETI_API_ROOT =.*#YETI_API_ROOT =  {{ printf "http://%s-yeti-api:%.0f/api/v2" .Release.Name .Values.global.yeti.servicePort | quote }}#' timesketch.conf
+    sed -i 's#^YETI_API_ROOT =.*#YETI_API_ROOT =  {{ printf "http://%s-yeti:%.0f/api/v2" .Release.Name .Values.global.yeti.servicePort | quote }}#' timesketch.conf
     {{- end }}

--- a/charts/yeti/values.yaml
+++ b/charts/yeti/values.yaml
@@ -447,7 +447,7 @@ arangodb:
     pullPolicy: Always
     ## @param arangodb.image.tag Overrides the image tag whose default is the chart appVersion
     ##
-    tag: latest
+    tag: 3.11.8
     ## @param arangodb.image.imagePullSecrets Specify secrets if pulling from a private repository
     ## ref https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
     ## e.g.


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

<!-- Describe what the change does. -->

Fixes the Timesketch config Yeti reference to point to the frontend service and lock arangodb to 3.11.8.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Newly added variables are documented in the values.yaml
- [ ] Title of the pull request is descriptive
