### PR TITLE
Adding basic HashR support

### DIFF
--- a/charts/hashr/.helmignore
+++ b/charts/hashr/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/hashr/Chart.lock
+++ b/charts/hashr/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 14.3.3
+digest: sha256:803fc388f1186ca5e0bf7af8597a7f94714bfe2fb4536d3ab2136e0b5ce1e59c
+generated: "2024-04-24T19:58:19.38937249Z"

--- a/charts/hashr/Chart.yaml
+++ b/charts/hashr/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: hashr
+description: A Helm chart for HashR Kubernetes deployments.
+version: 0.1.0
+type: application
+keywords:
+- hashr
+- dfir
+- analysis
+- security
+home: "https://github.com/google/hashr"
+dependencies:
+- condition: postgresql.enabled
+  name: postgresql
+  version: 14.3.3
+  repository: https://charts.bitnami.com/bitnami
+maintainers:
+  - name: Open Source DFIR
+    email: osdfir-maintainers@googlegroups.com
+    url: https://github.com/google/osdfir-infrastructure
+sources:
+- https://github.com/google/hashr
+- https://github.com/google/osdfir-infrastructure
+appVersion: "latest"
+annotations:
+  category: Security
+  licenses: Apache-2.0

--- a/charts/hashr/README.md
+++ b/charts/hashr/README.md
@@ -113,6 +113,73 @@ Please be cautious before doing it.
 
 ## Parameters
 
+### Global parameters
+
+| Name                            | Description                                                                                  | Value   |
+| ------------------------------- | -------------------------------------------------------------------------------------------- | ------- |
+| `global.timesketch.enabled`     | Enables the Timesketch deployment (only used in the main OSDFIR Infrastructure Helm chart)   | `false` |
+| `global.timesketch.servicePort` | Timesketch service port (overrides `timesketch.service.port`)                                | `nil`   |
+| `global.turbinia.enabled`       | Enables the Turbinia deployment (only used within the main OSDFIR Infrastructure Helm chart) | `false` |
+| `global.turbinia.servicePort`   | Turbinia API service port (overrides `turbinia.service.port`)                                | `nil`   |
+| `global.yeti.enabled`           | Enables the Yeti deployment (only used in the main OSDFIR Infrastructure Helm chart)         | `false` |
+| `global.yeti.servicePort`       | Yeti API service port (overrides `yeti.api.service.port`)                                    | `nil`   |
+| `global.existingPVC`            | Existing claim for HashR persistent volume (overrides `persistent.name`)                     | `""`    |
+| `global.storageClass`           | StorageClass for the HashR persistent volume (overrides `persistent.storageClass`)           | `""`    |
+
+### HashR image configuration
+
+| Name                     | Description                                                   | Value                                                   |
+| ------------------------ | ------------------------------------------------------------- | ------------------------------------------------------- |
+| `image.repository`       | HashR image repository                                        | `us-docker.pkg.dev/osdfir-registry/hashr/release/hashr` |
+| `image.pullPolicy`       | HashR image pull policy                                       | `IfNotPresent`                                          |
+| `image.tag`              | Overrides the image tag whose default is the chart appVersion | `latest`                                                |
+| `image.imagePullSecrets` | Specify secrets if pulling from a private repository          | `[]`                                                    |
+
+### HashR Configuration Paramters
+
+
+### Enable/Disable HashR importers
+
+| Name                               | Description                        | Value               |
+| ---------------------------------- | ---------------------------------- | ------------------- |
+| `hashr.importers.gcp.enabled`      | Enables the GCP importer           | `false`             |
+| `hashr.importers.gcp.schedule`     | sets the CronJob schedule times    | `0 3 * * 1`         |
+| `hashr.importers.targz.enabled`    | Enables the tar.gz importer        | `false`             |
+| `hashr.importers.targz.schedule`   | sets the CronJob schedule times    | `0 3 * * 2`         |
+| `hashr.importers.windows.enabled`  | Enables the Windows importer       | `false`             |
+| `hashr.importers.windows.schedule` | sets the CronJob schedule times    | `0 3 * * 3`         |
+| `hashr.importers.wsus.enabled`     | Enables the WSUS importer          | `false`             |
+| `hashr.importers.wsus.schedule`    | sets the CronJob schedule times    | `0 3 * * 4`         |
+| `hashr.importers.rpm.enabled`      | Enables the RPM importer           | `false`             |
+| `hashr.importers.rpm.schedule`     | sets the CronJob schedule times    | `0 3 * * 5`         |
+| `hashr.importers.zip.enabled`      | Enables the ZIP importer           | `false`             |
+| `hashr.importers.zip.schedule`     | sets the CronJob schedule times    | `0 3 * * 6`         |
+| `hashr.importers.gcr.enabled`      | Enables the GCR importer           | `false`             |
+| `hashr.importers.gcr.schedule`     | sets the CronJob schedule times    | `0 3 * * 7`         |
+| `hashr.importers.iso9660.enabled`  | Enables the iso9660 importer       | `false`             |
+| `hashr.importers.iso9660.schedule` | sets the CronJob schedule times    | `0 15 * * 1`        |
+| `hashr.importers.deb.enabled`      | Enables the DEB importer           | `false`             |
+| `hashr.importers.deb.schedule`     | sets the CronJob schedule times    | `0 15 * * 2`        |
+| `persistence.name`                 | HashR persistent volume name       | `hashrvolume`       |
+| `persistence.size`                 | HashR persistent volume size       | `50Gi`              |
+| `persistence.storageClass`         | PVC Storage Class for HashR volume | `""`                |
+| `persistence.accessModes`          | PVC Access Mode for HashR volume   | `["ReadWriteOnce"]` |
+
+### Postgresql Configuration Parameters
+
+| Name                                           | Description                                                                 | Value        |
+| ---------------------------------------------- | --------------------------------------------------------------------------- | ------------ |
+| `postgresql.enabled`                           | Enables the Postgresql deployment                                           | `true`       |
+| `postgresql.architecture`                      | PostgreSQL architecture (`standalone` or `replication`)                     | `standalone` |
+| `postgresql.auth.username`                     | Name for a custom PostgreSQL user to create                                 | `postgres`   |
+| `postgresql.auth.database`                     | Name for a custom PostgreSQL database to create (overrides `auth.database`) | `hashr`      |
+| `postgresql.primary.service.type`              | PostgreSQL primary service type                                             | `ClusterIP`  |
+| `postgresql.primary.service.ports.postgresql`  | PostgreSQL primary service port                                             | `5432`       |
+| `postgresql.primary.persistence.size`          | PostgreSQL Persistent Volume size                                           | `10Gi`       |
+| `postgresql.primary.resources.limits`          | The resources limits for the PostgreSQL primary containers                  | `{}`         |
+| `postgresql.primary.resources.requests.cpu`    | The requested cpu for the PostgreSQL primary containers                     | `250m`       |
+| `postgresql.primary.resources.requests.memory` | The requested memory for the PostgreSQL primary containers                  | `256Mi`      |
+
 
 
 ## Persistence

--- a/charts/hashr/README.md
+++ b/charts/hashr/README.md
@@ -1,0 +1,168 @@
+<!--- app-name: HashR -->
+# HashR Helm Chart
+
+HashR allows you to build your own hash sets based on your data sources. It's a
+tool that extracts files and hashes out of input sources (e.g. raw disk image,
+GCE disk image, ISO file, Windows update package, .tar.gz file, etc.).
+
+[Overview of HashR](https://github.com/google/hashr)
+
+[Chart Source Code](https://github.com/google/osdfir-infrastructure)
+
+## TL;DR
+
+```console
+helm repo add osdfir-charts https://google.github.io/osdfir-infrastructure/
+helm install my-release osdfir-charts/hashr
+```
+
+> **Tip**: To quickly get started with a local cluster, see
+[minikube install docs](https://minikube.sigs.k8s.io/docs/start/).
+
+## Introduction
+
+This chart bootstraps a [HashR](https://github.com/google/hashr/tree/main/docker)
+deployment on a [Kubernetes](https://kubernetes.io) cluster using the
+[Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+The first step is to add the repo and then update to pick up any new changes.
+
+```console
+helm repo add osdfir-charts https://google.github.io/osdfir-infrastructure/
+helm repo update
+```
+
+To install the chart, specify any release name of your choice. For example,
+using `my-release` as the release name, run:
+
+```console
+helm install my-release osdfir-charts/hashr
+```
+
+The command deploys a PostgreSQL instance to the Kubernetes cluster and
+schedules a Kubernetes CronJob to run the configures HashR job. Results of the
+HashR job are exported to the PostgreSQL instance.
+The [Parameters](#parameters) section lists the parameters that can be
+configured during installation.
+
+## Installing for Production
+
+Pull the chart locally then cd into `/hashr` and review the `values.yaml` file
+for a list of values that will be used for production.
+
+```console
+helm pull osdfir-charts/hashr --untar
+```
+
+Enable the HashR importers you want to use and define a schedule.
+
+Install the chart with the values in `values.yaml`, then using a release name
+such as `my-release`, run:
+
+```console
+helm install my-release ../hashr -f values.yaml
+```
+
+## Add data for HashR to process
+
+The HashR CronJob has access to the Persistent Volume (PVC) at `/mnt/hashrvolume`.
+See the [Persistence](#Persistence) section for more details.
+
+Each importer that needs local files to procress (e.g. deb, zip, iso9660, etc)
+will look in a subfolder of `/mnt/hashrvolume/data/<importer>` for files to
+process. E.g. `/mnt/hashrvolume/data/deb/`for the deb importer.
+
+To add data for processing use the `kubectl cp` command and the
+`hashr-data-manager` pod.
+
+Example:
+```
+kubectl cp <local PATH>/deb my-release-hashr-data-manager:/mnt/hashrvolume/data/
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete a Helm deployment with a release name of `my-release`:
+
+```console
+helm uninstall my-release
+```
+
+> **Tip**: Please update based on the release name chosen. You can list all
+releases using `helm list`
+
+The command removes all the Kubernetes components but Persistent Volumes (PVC)
+associated with the chart and deletes the release.
+
+To delete the PVC's associated with a release name of `my-release`:
+
+```console
+kubectl delete pvc -l release=my-release
+```
+
+> **Note**: Deleting the PVC's will delete HashR/PostgreSQL data as well.
+Please be cautious before doing it.
+
+## Parameters
+
+
+
+## Persistence
+
+The HashR deployment stores data at the `/mnt/hashrvolume` path of the
+container.
+
+Persistent Volume Claims are used to keep the data across deployments. This is
+known to work in GCP and Minikube. See the Parameters section to configure the
+PVC or to disable persistence.
+
+## Upgrading
+
+If you need to upgrade an existing release to update a value, such as persistent
+volume size or upgrading to a new release, you can run
+[helm upgrade](https://helm.sh/docs/helm/helm_upgrade/).
+For example, to set a new release and upgrade storage capacity, run:
+
+```console
+helm upgrade my-release ../hashr \
+    --set image.tag=latest \
+    --set persistence.size=10T
+```
+
+The above command upgrades an existing release named `my-release` updating the
+image tag to `latest` and increasing persistent volume size of an existing
+volume to 10 Terabytes. Note that existing data will not be deleted and instead
+triggers an expansion of the volume that backs the underlying PersistentVolume.
+See [here](https://kubernetes.io/docs/concepts/storage/persistent-volumes/).
+
+## Troubleshooting
+
+There is a known issue causing PostgreSQL authentication to fail. This occurs
+when you `delete` the deployed Helm chart and then redeploy the Chart without
+removing the existing PVCs. When redeploying, please ensure to delete the
+underlying PostgreSQL PVC. Refer to [issue 2061](https://github.com/bitnami/charts/issues/2061)
+for more details.
+
+## License
+
+Copyright &copy; 2024 OSDFIR Infrastructure
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+<http://www.apache.org/licenses/LICENSE-2.0>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/charts/hashr/README.md
+++ b/charts/hashr/README.md
@@ -124,6 +124,78 @@ Please be cautious before doing it.
 
 ## Parameters
 
+### Global parameters
+
+| Name                            | Description                                                                                  | Value   |
+| ------------------------------- | -------------------------------------------------------------------------------------------- | ------- |
+| `global.timesketch.enabled`     | Enables the Timesketch deployment (only used in the main OSDFIR Infrastructure Helm chart)   | `false` |
+| `global.timesketch.servicePort` | Timesketch service port (overrides `timesketch.service.port`)                                | `nil`   |
+| `global.turbinia.enabled`       | Enables the Turbinia deployment (only used within the main OSDFIR Infrastructure Helm chart) | `false` |
+| `global.turbinia.servicePort`   | Turbinia API service port (overrides `turbinia.service.port`)                                | `nil`   |
+| `global.yeti.enabled`           | Enables the Yeti deployment (only used in the main OSDFIR Infrastructure Helm chart)         | `false` |
+| `global.yeti.servicePort`       | Yeti API service port (overrides `yeti.api.service.port`)                                    | `nil`   |
+| `global.existingPVC`            | Existing claim for HashR persistent volume (overrides `persistent.name`)                     | `""`    |
+| `global.storageClass`           | StorageClass for the HashR persistent volume (overrides `persistent.storageClass`)           | `""`    |
+
+### HashR image configuration
+
+| Name                     | Description                                                   | Value                                                   |
+| ------------------------ | ------------------------------------------------------------- | ------------------------------------------------------- |
+| `image.repository`       | HashR image repository                                        | `us-docker.pkg.dev/osdfir-registry/hashr/release/hashr` |
+| `image.pullPolicy`       | HashR image pull policy                                       | `IfNotPresent`                                          |
+| `image.tag`              | Overrides the image tag whose default is the chart appVersion | `latest`                                                |
+| `image.imagePullSecrets` | Specify secrets if pulling from a private repository          | `[]`                                                    |
+
+### HashR Configuration Paramters
+
+
+### Enable/Disable HashR importers
+
+| Name                                    | Description                                                                                             | Value               |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------- |
+| `hashr.importers.aws.enabled`           | Enables the AWS importer                                                                                | `false`             |
+| `hashr.importers.aws.schedule`          | sets the CronJob schedule times                                                                         | `0 3 * * 1`         |
+| `hashr.importers.gcp.enabled`           | Enables the GCP importer                                                                                | `false`             |
+| `hashr.importers.gcp.schedule`          | sets the CronJob schedule times                                                                         | `0 3 * * 1`         |
+| `hashr.importers.gcp.gcp_projects`      | sets a comma separated list of cloud projects containing disk images                                    | `""`                |
+| `hashr.importers.gcp.hashr_gcp_project` | sets GCP project that will be used to store copy of disk images for processing and also run Cloud Build | `""`                |
+| `hashr.importers.gcp.hashr_gcs_bucket`  | sets GCS bucket that will be used to store output of Cloud Build (disk images in .tar.gz format)        | `""`                |
+| `hashr.importers.targz.enabled`         | Enables the tar.gz importer                                                                             | `false`             |
+| `hashr.importers.targz.schedule`        | sets the CronJob schedule times                                                                         | `0 3 * * 2`         |
+| `hashr.importers.windows.enabled`       | Enables the Windows importer                                                                            | `false`             |
+| `hashr.importers.windows.schedule`      | sets the CronJob schedule times                                                                         | `0 3 * * 3`         |
+| `hashr.importers.wsus.enabled`          | Enables the WSUS importer                                                                               | `false`             |
+| `hashr.importers.wsus.schedule`         | sets the CronJob schedule times                                                                         | `0 3 * * 4`         |
+| `hashr.importers.rpm.enabled`           | Enables the RPM importer                                                                                | `false`             |
+| `hashr.importers.rpm.schedule`          | sets the CronJob schedule times                                                                         | `0 3 * * 5`         |
+| `hashr.importers.zip.enabled`           | Enables the ZIP importer                                                                                | `false`             |
+| `hashr.importers.zip.schedule`          | sets the CronJob schedule times                                                                         | `0 3 * * 6`         |
+| `hashr.importers.gcr.enabled`           | Enables the GCR importer                                                                                | `false`             |
+| `hashr.importers.gcr.schedule`          | sets the CronJob schedule times                                                                         | `0 3 * * 7`         |
+| `hashr.importers.iso9660.enabled`       | Enables the iso9660 importer                                                                            | `false`             |
+| `hashr.importers.iso9660.schedule`      | sets the CronJob schedule times                                                                         | `0 15 * * 1`        |
+| `hashr.importers.deb.enabled`           | Enables the DEB importer                                                                                | `false`             |
+| `hashr.importers.deb.schedule`          | sets the CronJob schedule times                                                                         | `0 15 * * 2`        |
+| `persistence.name`                      | HashR persistent volume name                                                                            | `hashrvolume`       |
+| `persistence.size`                      | HashR persistent volume size                                                                            | `50Gi`              |
+| `persistence.storageClass`              | PVC Storage Class for HashR volume                                                                      | `""`                |
+| `persistence.accessModes`               | PVC Access Mode for HashR volume                                                                        | `["ReadWriteOnce"]` |
+
+### Postgresql Configuration Parameters
+
+| Name                                           | Description                                                                 | Value        |
+| ---------------------------------------------- | --------------------------------------------------------------------------- | ------------ |
+| `postgresql.enabled`                           | Enables the Postgresql deployment                                           | `true`       |
+| `postgresql.architecture`                      | PostgreSQL architecture (`standalone` or `replication`)                     | `standalone` |
+| `postgresql.auth.username`                     | Name for a custom PostgreSQL user to create                                 | `postgres`   |
+| `postgresql.auth.database`                     | Name for a custom PostgreSQL database to create (overrides `auth.database`) | `hashr`      |
+| `postgresql.primary.service.type`              | PostgreSQL primary service type                                             | `ClusterIP`  |
+| `postgresql.primary.service.ports.postgresql`  | PostgreSQL primary service port                                             | `5432`       |
+| `postgresql.primary.persistence.size`          | PostgreSQL Persistent Volume size                                           | `10Gi`       |
+| `postgresql.primary.resources.limits`          | The resources limits for the PostgreSQL primary containers                  | `{}`         |
+| `postgresql.primary.resources.requests.cpu`    | The requested cpu for the PostgreSQL primary containers                     | `250m`       |
+| `postgresql.primary.resources.requests.memory` | The requested memory for the PostgreSQL primary containers                  | `256Mi`      |
+
 
 
 ## Persistence

--- a/charts/hashr/README.md
+++ b/charts/hashr/README.md
@@ -84,7 +84,7 @@ helm install my-release ../hashr -f values.yaml
 ## Add data for HashR to process
 
 The HashR CronJob has access to the Persistent Volume (PVC) at `/mnt/hashrvolume`.
-See the [Persistence](#Persistence) section for more details.
+See the [Persistence](#persistence) section for more details.
 
 Each importer that needs local files to procress (e.g. deb, zip, iso9660, etc)
 will look in a subfolder of `/mnt/hashrvolume/data/<importer>` for files to
@@ -94,7 +94,8 @@ To add data for processing use the `kubectl cp` command and the
 `hashr-data-manager` pod.
 
 Example:
-```
+
+```console
 kubectl cp <local PATH>/deb my-release-hashr-data-manager:/mnt/hashrvolume/data/
 ```
 

--- a/charts/hashr/README.md
+++ b/charts/hashr/README.md
@@ -62,7 +62,17 @@ for a list of values that will be used for production.
 helm pull osdfir-charts/hashr --untar
 ```
 
-Enable the HashR importers you want to use and define a schedule.
+### Configure the HashR importers
+
+HashR provides different importers. Each importer has its own CronJob and can be
+configured separately. Enable and configure all importers you want to use in the
+`hashr.importers` section of the `values.yaml` file.
+
+Ensure that you have setup all requirements for the importers defined in the
+HashR project. See [HashR importers](https://github.com/google/hashr?tab=readme-ov-file#setting-up-importers)
+for more details.
+
+### Install chart
 
 Install the chart with the values in `values.yaml`, then using a release name
 such as `my-release`, run:
@@ -112,73 +122,6 @@ kubectl delete pvc -l release=my-release
 Please be cautious before doing it.
 
 ## Parameters
-
-### Global parameters
-
-| Name                            | Description                                                                                  | Value   |
-| ------------------------------- | -------------------------------------------------------------------------------------------- | ------- |
-| `global.timesketch.enabled`     | Enables the Timesketch deployment (only used in the main OSDFIR Infrastructure Helm chart)   | `false` |
-| `global.timesketch.servicePort` | Timesketch service port (overrides `timesketch.service.port`)                                | `nil`   |
-| `global.turbinia.enabled`       | Enables the Turbinia deployment (only used within the main OSDFIR Infrastructure Helm chart) | `false` |
-| `global.turbinia.servicePort`   | Turbinia API service port (overrides `turbinia.service.port`)                                | `nil`   |
-| `global.yeti.enabled`           | Enables the Yeti deployment (only used in the main OSDFIR Infrastructure Helm chart)         | `false` |
-| `global.yeti.servicePort`       | Yeti API service port (overrides `yeti.api.service.port`)                                    | `nil`   |
-| `global.existingPVC`            | Existing claim for HashR persistent volume (overrides `persistent.name`)                     | `""`    |
-| `global.storageClass`           | StorageClass for the HashR persistent volume (overrides `persistent.storageClass`)           | `""`    |
-
-### HashR image configuration
-
-| Name                     | Description                                                   | Value                                                   |
-| ------------------------ | ------------------------------------------------------------- | ------------------------------------------------------- |
-| `image.repository`       | HashR image repository                                        | `us-docker.pkg.dev/osdfir-registry/hashr/release/hashr` |
-| `image.pullPolicy`       | HashR image pull policy                                       | `IfNotPresent`                                          |
-| `image.tag`              | Overrides the image tag whose default is the chart appVersion | `latest`                                                |
-| `image.imagePullSecrets` | Specify secrets if pulling from a private repository          | `[]`                                                    |
-
-### HashR Configuration Paramters
-
-
-### Enable/Disable HashR importers
-
-| Name                               | Description                        | Value               |
-| ---------------------------------- | ---------------------------------- | ------------------- |
-| `hashr.importers.gcp.enabled`      | Enables the GCP importer           | `false`             |
-| `hashr.importers.gcp.schedule`     | sets the CronJob schedule times    | `0 3 * * 1`         |
-| `hashr.importers.targz.enabled`    | Enables the tar.gz importer        | `false`             |
-| `hashr.importers.targz.schedule`   | sets the CronJob schedule times    | `0 3 * * 2`         |
-| `hashr.importers.windows.enabled`  | Enables the Windows importer       | `false`             |
-| `hashr.importers.windows.schedule` | sets the CronJob schedule times    | `0 3 * * 3`         |
-| `hashr.importers.wsus.enabled`     | Enables the WSUS importer          | `false`             |
-| `hashr.importers.wsus.schedule`    | sets the CronJob schedule times    | `0 3 * * 4`         |
-| `hashr.importers.rpm.enabled`      | Enables the RPM importer           | `false`             |
-| `hashr.importers.rpm.schedule`     | sets the CronJob schedule times    | `0 3 * * 5`         |
-| `hashr.importers.zip.enabled`      | Enables the ZIP importer           | `false`             |
-| `hashr.importers.zip.schedule`     | sets the CronJob schedule times    | `0 3 * * 6`         |
-| `hashr.importers.gcr.enabled`      | Enables the GCR importer           | `false`             |
-| `hashr.importers.gcr.schedule`     | sets the CronJob schedule times    | `0 3 * * 7`         |
-| `hashr.importers.iso9660.enabled`  | Enables the iso9660 importer       | `false`             |
-| `hashr.importers.iso9660.schedule` | sets the CronJob schedule times    | `0 15 * * 1`        |
-| `hashr.importers.deb.enabled`      | Enables the DEB importer           | `false`             |
-| `hashr.importers.deb.schedule`     | sets the CronJob schedule times    | `0 15 * * 2`        |
-| `persistence.name`                 | HashR persistent volume name       | `hashrvolume`       |
-| `persistence.size`                 | HashR persistent volume size       | `50Gi`              |
-| `persistence.storageClass`         | PVC Storage Class for HashR volume | `""`                |
-| `persistence.accessModes`          | PVC Access Mode for HashR volume   | `["ReadWriteOnce"]` |
-
-### Postgresql Configuration Parameters
-
-| Name                                           | Description                                                                 | Value        |
-| ---------------------------------------------- | --------------------------------------------------------------------------- | ------------ |
-| `postgresql.enabled`                           | Enables the Postgresql deployment                                           | `true`       |
-| `postgresql.architecture`                      | PostgreSQL architecture (`standalone` or `replication`)                     | `standalone` |
-| `postgresql.auth.username`                     | Name for a custom PostgreSQL user to create                                 | `postgres`   |
-| `postgresql.auth.database`                     | Name for a custom PostgreSQL database to create (overrides `auth.database`) | `hashr`      |
-| `postgresql.primary.service.type`              | PostgreSQL primary service type                                             | `ClusterIP`  |
-| `postgresql.primary.service.ports.postgresql`  | PostgreSQL primary service port                                             | `5432`       |
-| `postgresql.primary.persistence.size`          | PostgreSQL Persistent Volume size                                           | `10Gi`       |
-| `postgresql.primary.resources.limits`          | The resources limits for the PostgreSQL primary containers                  | `{}`         |
-| `postgresql.primary.resources.requests.cpu`    | The requested cpu for the PostgreSQL primary containers                     | `250m`       |
-| `postgresql.primary.resources.requests.memory` | The requested memory for the PostgreSQL primary containers                  | `256Mi`      |
 
 
 

--- a/charts/hashr/README.md
+++ b/charts/hashr/README.md
@@ -154,7 +154,7 @@ Please be cautious before doing it.
 | Name                                    | Description                                                                                             | Value               |
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------- |
 | `hashr.importers.aws.enabled`           | Enables the AWS importer                                                                                | `false`             |
-| `hashr.importers.aws.schedule`          | sets the CronJob schedule times                                                                         | `0 3 * * 1`         |
+| `hashr.importers.aws.schedule`          | sets the CronJob schedule times                                                                         | `0 9 * * 1`         |
 | `hashr.importers.gcp.enabled`           | Enables the GCP importer                                                                                | `false`             |
 | `hashr.importers.gcp.schedule`          | sets the CronJob schedule times                                                                         | `0 3 * * 1`         |
 | `hashr.importers.gcp.gcp_projects`      | sets a comma separated list of cloud projects containing disk images                                    | `""`                |

--- a/charts/hashr/templates/_helpers.tpl
+++ b/charts/hashr/templates/_helpers.tpl
@@ -1,0 +1,107 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hashr.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hashr.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hashr.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "hashr.labels" -}}
+helm.sh/chart: {{ include "hashr.chart" . }}
+{{ include "hashr.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hashr.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hashr.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "hashr.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "hashr.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the proper persistence volume claim name
+*/}}
+{{- define "hashr.pvc.name" -}}
+{{- $pvcName := .Values.persistence.name -}}
+{{- if .Values.global -}}
+    {{- if .Values.global.existingPVC -}}
+        {{- $pvcName = .Values.global.existingPVC -}}
+    {{- end -}}
+{{- printf "%s-%s" $pvcName "claim" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Storage Class
+*/}}
+{{- define "hashr.storage.class" -}}
+{{- $storageClass := .Values.persistence.storageClass -}}
+{{- if .Values.global -}}
+    {{- if .Values.global.storageClass -}}
+        {{- $storageClass = .Values.global.storageClass -}}
+    {{- end -}}
+{{- end -}}
+{{- if $storageClass -}}
+  {{- if (eq "-" $storageClass) -}}
+      {{- printf "storageClassName: \"\"" -}}
+  {{- else }}
+      {{- printf "storageClassName: %s" $storageClass -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the data path.
+*/}}
+{{- define "hashr.dataPath" -}}
+{{- $pvcName := .Values.persistence.name -}}
+{{- if .Values.global -}}
+    {{- if .Values.global.existingPVC -}}
+        {{- $pvcName = .Values.global.existingPVC -}}
+    {{- end -}}
+{{- printf "/mnt/%s/data" $pvcName }}
+{{- end }}
+{{- end }}

--- a/charts/hashr/templates/data-manager.yaml
+++ b/charts/hashr/templates/data-manager.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-hashr-data-manager
+spec:
+  containers:
+  - name: hashr-data-manager
+    image: busybox:latest
+    imagePullPolicy: IfNotPresent
+    command: ["sh", "-c", "while true; do sleep 1800; done;"]
+    volumeMounts:
+    - name: hashrvolume
+      mountPath: {{ (include "hashr.dataPath" .) | quote }}
+  restartPolicy: Always
+  volumes:
+  - name: hashrvolume
+    persistentVolumeClaim:
+      claimName: {{ include "hashr.pvc.name"  . }}
+      readOnly: false

--- a/charts/hashr/templates/hashr-deb-cronjob.yaml
+++ b/charts/hashr/templates/hashr-deb-cronjob.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.hashr.importers.deb -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-hashr-deb
+spec:
+  schedule: {{ .Values.hashr.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hashr-deb
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            args:
+              - -storage
+              - postgres
+              - -exporters
+              - postgres
+              - -postgres_host
+              - {{ include "common.names.fullname" (dict "Chart" (dict "Name" "postgresql") "Release" .Release "Values" .Values.postgresql) }}
+              - -postgres_port
+              - {{ .Values.postgresql.primary.service.ports.postgresql | quote }}
+              - -postgres_user
+              - {{ .Values.postgresql.auth.username | quote }}
+              - -postgres_password
+              - "$(POSTGRES_PASSWORD)"
+              - -postgres_db
+              - {{ .Values.postgresql.auth.database | quote }}
+              - -importers
+              - deb
+              - -deb_repo_path
+              - {{ (include "hashr.dataPath" .) }}/deb/
+            env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgresql.v1.secretName" .Subcharts.postgresql }}
+                  key: {{ include "postgresql.v1.adminPasswordKey" .Subcharts.postgresql }}
+            volumeMounts:
+            - name: hashrvolume
+              mountPath: {{ (include "hashr.dataPath" .) | quote }}
+          restartPolicy: Never
+          volumes:
+          - name: hashrvolume
+            persistentVolumeClaim:
+              claimName: {{ include "hashr.pvc.name"  . }}
+              readOnly: false
+{{- end }}

--- a/charts/hashr/templates/hashr-deb-cronjob.yaml
+++ b/charts/hashr/templates/hashr-deb-cronjob.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.hashr.importers.deb -}}
+{{- if .Values.hashr.importers.deb.enabled -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-hashr-deb
 spec:
-  schedule: {{ .Values.hashr.schedule | quote }}
+  schedule: {{ .Values.hashr.importers.deb.schedule | quote }}
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1

--- a/charts/hashr/templates/hashr-gcp-cronjob.yaml
+++ b/charts/hashr/templates/hashr-gcp-cronjob.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.hashr.importers.deb.enabled -}}
+{{- if .Values.hashr.importers.gcp.enabled -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-hashr-deb
+  name: {{ .Release.Name }}-hashr-gcp
 spec:
-  schedule: {{ .Values.hashr.importers.deb.schedule | quote }}
+  schedule: {{ .Values.hashr.importers.gcp.schedule | quote }}
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 1
@@ -13,7 +13,7 @@ spec:
       template:
         spec:
           containers:
-          - name: hashr-deb
+          - name: hashr-gcp
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             args:
@@ -33,10 +33,18 @@ spec:
               - -postgres_db
               - {{ .Values.postgresql.auth.database | quote }}
               - -importers
-              - deb
-              - -deb_repo_path
-              - {{ (include "hashr.dataPath" .) }}/deb/
+              - GCP
+              - -gcp_projects
+              - {{ .Values.hashr.importers.gcp.gcp_projects | quote }}
+              - -hashr_gcp_project
+              - {{ .Values.hashr.importers.gcp.hashr_gcp_project | quote }}
+              - -hashr_gcs_bucket
+              - {{ .Values.hashr.importers.gcp.hashr_gcs_bucket | quote }}
             env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              # Store your SA key in the hashrvolume/creds/ folder via "kubectl cp"!
+              # chown 999:1000 hashr-sa-private-key.json to prevent permission issues
+              value: {{ (include "hashr.dataPath" .) }}/creds/hashr-sa-private-key.json
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/hashr/templates/hashr-iso9660-cronjob.yaml
+++ b/charts/hashr/templates/hashr-iso9660-cronjob.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.hashr.importers.deb.enabled -}}
+{{- if .Values.hashr.importers.iso9660.enabled -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-hashr-deb
+  name: {{ .Release.Name }}-hashr-iso9660
 spec:
-  schedule: {{ .Values.hashr.importers.deb.schedule | quote }}
+  schedule: {{ .Values.hashr.importers.iso9660.schedule | quote }}
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 1
@@ -13,7 +13,7 @@ spec:
       template:
         spec:
           containers:
-          - name: hashr-deb
+          - name: hashr-iso9660
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             args:
@@ -33,9 +33,9 @@ spec:
               - -postgres_db
               - {{ .Values.postgresql.auth.database | quote }}
               - -importers
-              - deb
-              - -deb_repo_path
-              - {{ (include "hashr.dataPath" .) }}/deb/
+              - iso9660
+              - -iso_repo_path
+              - {{ (include "hashr.dataPath" .) }}/iso9660/
             env:
             - name: POSTGRES_PASSWORD
               valueFrom:

--- a/charts/hashr/templates/hashr-rpm-cronjob.yaml
+++ b/charts/hashr/templates/hashr-rpm-cronjob.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.hashr.importers.deb.enabled -}}
+{{- if .Values.hashr.importers.rpm.enabled -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-hashr-deb
+  name: {{ .Release.Name }}-hashr-rpm
 spec:
-  schedule: {{ .Values.hashr.importers.deb.schedule | quote }}
+  schedule: {{ .Values.hashr.importers.rpm.schedule | quote }}
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 1
@@ -13,7 +13,7 @@ spec:
       template:
         spec:
           containers:
-          - name: hashr-deb
+          - name: hashr-rpm
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             args:
@@ -33,9 +33,9 @@ spec:
               - -postgres_db
               - {{ .Values.postgresql.auth.database | quote }}
               - -importers
-              - deb
-              - -deb_repo_path
-              - {{ (include "hashr.dataPath" .) }}/deb/
+              - rpm
+              - -rpm_repo_path
+              - {{ (include "hashr.dataPath" .) }}/rpm/
             env:
             - name: POSTGRES_PASSWORD
               valueFrom:

--- a/charts/hashr/templates/hashr-targz-cronjob.yaml
+++ b/charts/hashr/templates/hashr-targz-cronjob.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.hashr.importers.deb.enabled -}}
+{{- if .Values.hashr.importers.targz.enabled -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-hashr-deb
+  name: {{ .Release.Name }}-hashr-targz
 spec:
-  schedule: {{ .Values.hashr.importers.deb.schedule | quote }}
+  schedule: {{ .Values.hashr.importers.targz.schedule | quote }}
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 1
@@ -13,7 +13,7 @@ spec:
       template:
         spec:
           containers:
-          - name: hashr-deb
+          - name: hashr-targz
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             args:
@@ -33,9 +33,9 @@ spec:
               - -postgres_db
               - {{ .Values.postgresql.auth.database | quote }}
               - -importers
-              - deb
-              - -deb_repo_path
-              - {{ (include "hashr.dataPath" .) }}/deb/
+              - targz
+              - -targz_repo_path
+              - {{ (include "hashr.dataPath" .) }}/targz/
             env:
             - name: POSTGRES_PASSWORD
               valueFrom:

--- a/charts/hashr/templates/hashr-zip-cronjob.yaml
+++ b/charts/hashr/templates/hashr-zip-cronjob.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.hashr.importers.deb.enabled -}}
+{{- if .Values.hashr.importers.zip.enabled -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-hashr-deb
+  name: {{ .Release.Name }}-hashr-zip
 spec:
-  schedule: {{ .Values.hashr.importers.deb.schedule | quote }}
+  schedule: {{ .Values.hashr.importers.zip.schedule | quote }}
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 1
@@ -13,7 +13,7 @@ spec:
       template:
         spec:
           containers:
-          - name: hashr-deb
+          - name: hashr-zip
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             args:
@@ -33,9 +33,9 @@ spec:
               - -postgres_db
               - {{ .Values.postgresql.auth.database | quote }}
               - -importers
-              - deb
-              - -deb_repo_path
-              - {{ (include "hashr.dataPath" .) }}/deb/
+              - zip
+              - -zip_repo_path
+              - {{ (include "hashr.dataPath" .) }}/zip/
             env:
             - name: POSTGRES_PASSWORD
               valueFrom:

--- a/charts/hashr/templates/pvc.yaml
+++ b/charts/hashr/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if not (.Values.global.existingPVC) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  name: {{ include "hashr.pvc.name"  . }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  {{- include "hashr.storage.class" . | nindent 2 }}
+  accessModes:
+    {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/charts/hashr/values.yaml
+++ b/charts/hashr/values.yaml
@@ -171,4 +171,3 @@ postgresql:
       requests:
         cpu: 250m
         memory: 256Mi
-

--- a/charts/hashr/values.yaml
+++ b/charts/hashr/values.yaml
@@ -28,10 +28,10 @@ global:
     ## @param global.yeti.servicePort Yeti API service port (overrides `yeti.api.service.port`)
     ##
     servicePort:
-  ## @param global.existingPVC Existing claim for Timesketch persistent volume (overrides `persistent.name`)
+  ## @param global.existingPVC Existing claim for HashR persistent volume (overrides `persistent.name`)
   ##
   existingPVC: ""
-  ## @param global.storageClass StorageClass for the Timesketch persistent volume (overrides `persistent.storageClass`)
+  ## @param global.storageClass StorageClass for the HashR persistent volume (overrides `persistent.storageClass`)
   ##
   storageClass: ""
 ## @section HashR image configuration
@@ -57,50 +57,84 @@ image:
 ## @section HashR Configuration Paramters
 ##
 hashr:
-  ## @param hashr.schedule Sets the cronjob schedule for running HashR
-  ##
-  schedule: "*/3 * * * *"
   ## @section Enable/Disable HashR importers
   ##
   importers:
-    ## List of importers: GCP,targz,windows,wsus,deb,rpm,zip,gcr,iso9660
-    ## @param hashr.importers.gcp Enables the GCP importer
+    ## List of HashR importers and their settings
     ##
-    gcp: false
-    ## @param hashr.importers.targz Enables the tar.gz importer
-    ##
-    targz: false
-    ## @param hashr.importers.windows Enables the Windows importer
-    ##
-    windows: false
-    ## @param hashr.importers.wsus Enables the WSUS importer
-    ##
-    wsus: false
-    ## @param hashr.importers.rpm Enables the RPM importer
-    ##
-    rpm: false
-    ## @param hashr.importers.zip Enables the ZIP importer
-    ##
-    zip: false
-    ## @param hashr.importers.gcr Enables the GCR importer
-    ##
-    gcr: false
-    ## @param hashr.importers.iso9660 Enables the iso9660 importer
-    ##
-    iso9660: false
-    ## @param hashr.importers.deb Enables the DEB importer
-    ##
-    deb: true
+    gcp:
+      ## @param hashr.importers.gcp.enabled Enables the GCP importer
+      ##
+      enabled: false
+      ## @param hashr.importers.gcp.schedule sets the CronJob schedule times
+      ##
+      schedule: "0 3 * * 1" # At 03:00 on Monday
+    targz:
+      ## @param hashr.importers.targz.enabled Enables the tar.gz importer
+      ##
+      enabled: false
+      ## @param hashr.importers.targz.schedule sets the CronJob schedule times
+      ##
+      schedule: "0 3 * * 2" # At 03:00 on Tuesday
+    windows:
+      ## @param hashr.importers.windows.enabled Enables the Windows importer
+      ##
+      enabled: false
+      ## @param hashr.importers.windows.schedule sets the CronJob schedule times
+      ##
+      schedule: "0 3 * * 3" # At 03:00 on Wednesday
+    wsus:
+      ## @param hashr.importers.wsus.enabled Enables the WSUS importer
+      ##
+      enabled: false
+      ## @param hashr.importers.wsus.schedule sets the CronJob schedule times
+      ##
+      schedule: "0 3 * * 4" # At 03:00 on Thursday
+    rpm:
+      ## @param hashr.importers.rpm.enabled Enables the RPM importer
+      ##
+      enabled: false
+      ## @param hashr.importers.rpm.schedule sets the CronJob schedule times
+      ##
+      schedule: "0 3 * * 5" # At 03:00 on Friday
+    zip:
+      ## @param hashr.importers.zip.enabled Enables the ZIP importer
+      ##
+      enabled: false
+      ## @param hashr.importers.zip.schedule sets the CronJob schedule times
+      ##
+      schedule: "0 3 * * 6" # At 03:00 on Saturday
+    gcr:
+      ## @param hashr.importers.gcr.enabled Enables the GCR importer
+      ##
+      enabled: false
+      ## @param hashr.importers.gcr.schedule sets the CronJob schedule times
+      ##
+      schedule: "0 3 * * 7" # At 03:00 on Sunday
+    iso9660:
+      ## @param hashr.importers.iso9660.enabled Enables the iso9660 importer
+      ##
+      enabled: false
+      ## @param hashr.importers.iso9660.schedule sets the CronJob schedule times
+      ##
+      schedule: "0 15 * * 1" # At 15:00 on Monday
+    deb:
+      ## @param hashr.importers.deb.enabled Enables the DEB importer
+      ##
+      enabled: false
+      ## @param hashr.importers.deb.schedule sets the CronJob schedule times
+      ##
+      schedule: "0 15 * * 2" # At 15:00 on Tuesday
 ## Persistence Storage Parameters
 ##
 persistence:
-  ## @param persistence.name Timesketch persistent volume name
+  ## @param persistence.name HashR persistent volume name
   ##
   name: hashrvolume
-  ## @param persistence.size Timesketch persistent volume size
+  ## @param persistence.size HashR persistent volume size
   ##
-  size: 2Gi
-  ## @param persistence.storageClass PVC Storage Class for Timesketch volume
+  size: 50Gi
+  ## @param persistence.storageClass PVC Storage Class for HashR volume
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined or set to null, no storageClassName spec is
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
@@ -108,7 +142,7 @@ persistence:
   ## ref https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/#using-dynamic-provisioning
   ##
   storageClass: ""
-  ## @param persistence.accessModes PVC Access Mode for Timesketch volume
+  ## @param persistence.accessModes PVC Access Mode for HashR volume
   ## Access mode may need to be updated based on the StorageClass
   ## ref https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
   ##
@@ -152,7 +186,7 @@ postgresql:
     persistence:
       ## @param postgresql.primary.persistence.size PostgreSQL Persistent Volume size
       ##
-      size: 2Gi
+      size: 10Gi
     ## PostgreSQL primary resource requests and limits
     ## @param postgresql.primary.resources.limits The resources limits for the PostgreSQL primary containers
     ## @param postgresql.primary.resources.requests.cpu The requested cpu for the PostgreSQL primary containers

--- a/charts/hashr/values.yaml
+++ b/charts/hashr/values.yaml
@@ -84,13 +84,13 @@ hashr:
       ##
       # At 03:00 on Monday
       schedule: "0 3 * * 1"
-      ## @param hashr.importers.gcp.gcpProjects sets a comma separated list of cloud projects containing disk images
+      ## @param hashr.importers.gcp.gcp_projects sets a comma separated list of cloud projects containing disk images
       ##
       gcp_projects: ""
-      ## @param hashr.importers.gcp.hashrGCPProject sets GCP project that will be used to store copy of disk images for processing and also run Cloud Build
+      ## @param hashr.importers.gcp.hashr_gcp_project sets GCP project that will be used to store copy of disk images for processing and also run Cloud Build
       ##
       hashr_gcp_project: ""
-      ## @param hashr.importers.gcp.hashrGCSBucket sets GCS bucket that will be used to store output of Cloud Build (disk images in .tar.gz format)
+      ## @param hashr.importers.gcp.hashr_gcs_bucket sets GCS bucket that will be used to store output of Cloud Build (disk images in .tar.gz format)
       ##
       hashr_gcs_bucket: ""
     targz:

--- a/charts/hashr/values.yaml
+++ b/charts/hashr/values.yaml
@@ -70,7 +70,8 @@ hashr:
       enabled: false
       ## @param hashr.importers.aws.schedule sets the CronJob schedule times
       ##
-      schedule: "0 3 * * 1" # At 03:00 on Monday
+      # At 03:00 on Monday
+      schedule: "0 3 * * 1"
     gcp:
       # Ensure you have the correct setup before enabling this importer:
       # https://github.com/google/hashr?tab=readme-ov-file#gcp-google-cloud-platform
@@ -81,7 +82,8 @@ hashr:
       enabled: false
       ## @param hashr.importers.gcp.schedule sets the CronJob schedule times
       ##
-      schedule: "0 3 * * 1" # At 03:00 on Monday
+      # At 03:00 on Monday
+      schedule: "0 3 * * 1"
       ## @param hashr.importers.gcp.gcpProjects sets a comma separated list of cloud projects containing disk images
       ##
       gcp_projects: ""
@@ -98,7 +100,8 @@ hashr:
       enabled: false
       ## @param hashr.importers.targz.schedule sets the CronJob schedule times
       ##
-      schedule: "0 3 * * 2" # At 03:00 on Tuesday
+      # At 03:00 on Tuesday
+      schedule: "0 3 * * 2"
     windows:
       # TODO: Add cronjob file!
       # https://github.com/google/hashr?tab=readme-ov-file#windows
@@ -107,7 +110,8 @@ hashr:
       enabled: false
       ## @param hashr.importers.windows.schedule sets the CronJob schedule times
       ##
-      schedule: "0 3 * * 3" # At 03:00 on Wednesday
+      # At 03:00 on Wednesday
+      schedule: "0 3 * * 3"
     wsus:
       # TODO: Add cronjob file!
       # https://github.com/google/hashr?tab=readme-ov-file#wsus
@@ -116,7 +120,8 @@ hashr:
       enabled: false
       ## @param hashr.importers.wsus.schedule sets the CronJob schedule times
       ##
-      schedule: "0 3 * * 4" # At 03:00 on Thursday
+      # At 03:00 on Thursday
+      schedule: "0 3 * * 4"
     rpm:
       # https://github.com/google/hashr?tab=readme-ov-file#rpm
       ## @param hashr.importers.rpm.enabled Enables the RPM importer
@@ -124,7 +129,8 @@ hashr:
       enabled: false
       ## @param hashr.importers.rpm.schedule sets the CronJob schedule times
       ##
-      schedule: "0 3 * * 5" # At 03:00 on Friday
+      # At 03:00 on Friday
+      schedule: "0 3 * * 5"
     zip:
       # https://github.com/google/hashr?tab=readme-ov-file#zip-and-other-zip-like-formats
       ## @param hashr.importers.zip.enabled Enables the ZIP importer
@@ -132,7 +138,8 @@ hashr:
       enabled: false
       ## @param hashr.importers.zip.schedule sets the CronJob schedule times
       ##
-      schedule: "0 3 * * 6" # At 03:00 on Saturday
+      # At 03:00 on Saturday
+      schedule: "0 3 * * 6"
     gcr:
       # TODO: Add cronjob file!
       # https://github.com/google/hashr?tab=readme-ov-file#gcr-google-container-registry
@@ -141,7 +148,8 @@ hashr:
       enabled: false
       ## @param hashr.importers.gcr.schedule sets the CronJob schedule times
       ##
-      schedule: "0 3 * * 7" # At 03:00 on Sunday
+      # At 03:00 on Sunday
+      schedule: "0 3 * * 7"
     iso9660:
       # https://github.com/google/hashr?tab=readme-ov-file#iso-9660
       ## @param hashr.importers.iso9660.enabled Enables the iso9660 importer
@@ -149,7 +157,8 @@ hashr:
       enabled: false
       ## @param hashr.importers.iso9660.schedule sets the CronJob schedule times
       ##
-      schedule: "0 15 * * 1" # At 15:00 on Monday
+      # At 15:00 on Monday
+      schedule: "0 15 * * 1"
     deb:
       # https://github.com/google/hashr?tab=readme-ov-file#deb
       ## @param hashr.importers.deb.enabled Enables the DEB importer
@@ -157,7 +166,8 @@ hashr:
       enabled: false
       ## @param hashr.importers.deb.schedule sets the CronJob schedule times
       ##
-      schedule: "0 15 * * 2" # At 15:00 on Tuesday
+      # At 15:00 on Tuesday
+      schedule: "0 15 * * 2"
 ## Persistence Storage Parameters
 ##
 persistence:

--- a/charts/hashr/values.yaml
+++ b/charts/hashr/values.yaml
@@ -70,8 +70,8 @@ hashr:
       enabled: false
       ## @param hashr.importers.aws.schedule sets the CronJob schedule times
       ##
-      # At 03:00 on Monday
-      schedule: "0 3 * * 1"
+      # At 09:00 on Monday
+      schedule: "0 9 * * 1"
     gcp:
       # Ensure you have the correct setup before enabling this importer:
       # https://github.com/google/hashr?tab=readme-ov-file#gcp-google-cloud-platform

--- a/charts/hashr/values.yaml
+++ b/charts/hashr/values.yaml
@@ -62,7 +62,8 @@ hashr:
   importers:
     ## List of HashR importers and their settings
     ##
-    aws: # TODO: Add cronjob file!
+    aws:
+      # TODO: Add cronjob file!
       # https://github.com/google/hashr?tab=readme-ov-file#aws
       ## @param hashr.importers.aws.enabled Enables the AWS importer
       ##
@@ -98,7 +99,8 @@ hashr:
       ## @param hashr.importers.targz.schedule sets the CronJob schedule times
       ##
       schedule: "0 3 * * 2" # At 03:00 on Tuesday
-    windows:  # TODO: Add cronjob file!
+    windows:
+      # TODO: Add cronjob file!
       # https://github.com/google/hashr?tab=readme-ov-file#windows
       ## @param hashr.importers.windows.enabled Enables the Windows importer
       ##
@@ -106,7 +108,8 @@ hashr:
       ## @param hashr.importers.windows.schedule sets the CronJob schedule times
       ##
       schedule: "0 3 * * 3" # At 03:00 on Wednesday
-    wsus:  # TODO: Add cronjob file!
+    wsus:
+      # TODO: Add cronjob file!
       # https://github.com/google/hashr?tab=readme-ov-file#wsus
       ## @param hashr.importers.wsus.enabled Enables the WSUS importer
       ##
@@ -130,7 +133,8 @@ hashr:
       ## @param hashr.importers.zip.schedule sets the CronJob schedule times
       ##
       schedule: "0 3 * * 6" # At 03:00 on Saturday
-    gcr:  # TODO: Add cronjob file!
+    gcr:
+      # TODO: Add cronjob file!
       # https://github.com/google/hashr?tab=readme-ov-file#gcr-google-container-registry
       ## @param hashr.importers.gcr.enabled Enables the GCR importer
       ##

--- a/charts/hashr/values.yaml
+++ b/charts/hashr/values.yaml
@@ -62,28 +62,52 @@ hashr:
   importers:
     ## List of HashR importers and their settings
     ##
+    aws: # TODO: Add cronjob file!
+      # https://github.com/google/hashr?tab=readme-ov-file#aws
+      ## @param hashr.importers.aws.enabled Enables the AWS importer
+      ##
+      enabled: false
+      ## @param hashr.importers.aws.schedule sets the CronJob schedule times
+      ##
+      schedule: "0 3 * * 1" # At 03:00 on Monday
     gcp:
+      # Ensure you have the correct setup before enabling this importer:
+      # https://github.com/google/hashr?tab=readme-ov-file#gcp-google-cloud-platform
+      # IMPORTANT: Store your SA key in the hashrvolume via kubectl cp!
+      # e.g. kubectl cp ~/hashr-sa-private-key.json hashr-data-manager:/mnt/hashrvolume/data/creds/hashr-sa-private-key.json
       ## @param hashr.importers.gcp.enabled Enables the GCP importer
       ##
       enabled: false
       ## @param hashr.importers.gcp.schedule sets the CronJob schedule times
       ##
       schedule: "0 3 * * 1" # At 03:00 on Monday
+      ## @param hashr.importers.gcp.gcpProjects sets a comma separated list of cloud projects containing disk images
+      ##
+      gcp_projects: ""
+      ## @param hashr.importers.gcp.hashrGCPProject sets GCP project that will be used to store copy of disk images for processing and also run Cloud Build
+      ##
+      hashr_gcp_project: ""
+      ## @param hashr.importers.gcp.hashrGCSBucket sets GCS bucket that will be used to store output of Cloud Build (disk images in .tar.gz format)
+      ##
+      hashr_gcs_bucket: ""
     targz:
+      # https://github.com/google/hashr?tab=readme-ov-file#targz
       ## @param hashr.importers.targz.enabled Enables the tar.gz importer
       ##
       enabled: false
       ## @param hashr.importers.targz.schedule sets the CronJob schedule times
       ##
       schedule: "0 3 * * 2" # At 03:00 on Tuesday
-    windows:
+    windows:  # TODO: Add cronjob file!
+      # https://github.com/google/hashr?tab=readme-ov-file#windows
       ## @param hashr.importers.windows.enabled Enables the Windows importer
       ##
       enabled: false
       ## @param hashr.importers.windows.schedule sets the CronJob schedule times
       ##
       schedule: "0 3 * * 3" # At 03:00 on Wednesday
-    wsus:
+    wsus:  # TODO: Add cronjob file!
+      # https://github.com/google/hashr?tab=readme-ov-file#wsus
       ## @param hashr.importers.wsus.enabled Enables the WSUS importer
       ##
       enabled: false
@@ -91,6 +115,7 @@ hashr:
       ##
       schedule: "0 3 * * 4" # At 03:00 on Thursday
     rpm:
+      # https://github.com/google/hashr?tab=readme-ov-file#rpm
       ## @param hashr.importers.rpm.enabled Enables the RPM importer
       ##
       enabled: false
@@ -98,13 +123,15 @@ hashr:
       ##
       schedule: "0 3 * * 5" # At 03:00 on Friday
     zip:
+      # https://github.com/google/hashr?tab=readme-ov-file#zip-and-other-zip-like-formats
       ## @param hashr.importers.zip.enabled Enables the ZIP importer
       ##
       enabled: false
       ## @param hashr.importers.zip.schedule sets the CronJob schedule times
       ##
       schedule: "0 3 * * 6" # At 03:00 on Saturday
-    gcr:
+    gcr:  # TODO: Add cronjob file!
+      # https://github.com/google/hashr?tab=readme-ov-file#gcr-google-container-registry
       ## @param hashr.importers.gcr.enabled Enables the GCR importer
       ##
       enabled: false
@@ -112,6 +139,7 @@ hashr:
       ##
       schedule: "0 3 * * 7" # At 03:00 on Sunday
     iso9660:
+      # https://github.com/google/hashr?tab=readme-ov-file#iso-9660
       ## @param hashr.importers.iso9660.enabled Enables the iso9660 importer
       ##
       enabled: false
@@ -119,6 +147,7 @@ hashr:
       ##
       schedule: "0 15 * * 1" # At 15:00 on Monday
     deb:
+      # https://github.com/google/hashr?tab=readme-ov-file#deb
       ## @param hashr.importers.deb.enabled Enables the DEB importer
       ##
       enabled: false

--- a/charts/hashr/values.yaml
+++ b/charts/hashr/values.yaml
@@ -1,0 +1,174 @@
+## HashR Helm Chart
+## Please use this Helm chart for deploying HashR to a Kubernetes environment
+##
+## @section Global parameters
+## Please, note that this will override the parameters configured to use the global value
+##
+global:
+  ## Global Persistence Configuration
+  ##
+  timesketch:
+    ## @param global.timesketch.enabled Enables the Timesketch deployment (only used in the main OSDFIR Infrastructure Helm chart)
+    ##
+    enabled: false
+    ## @param global.timesketch.servicePort Timesketch service port (overrides `timesketch.service.port`)
+    ##
+    servicePort:
+  turbinia:
+    ## @param global.turbinia.enabled Enables the Turbinia deployment (only used within the main OSDFIR Infrastructure Helm chart)
+    ##
+    enabled: false
+    ## @param global.turbinia.servicePort Turbinia API service port (overrides `turbinia.service.port`)
+    ##
+    servicePort:
+  yeti:
+    ## @param global.yeti.enabled Enables the Yeti deployment (only used in the main OSDFIR Infrastructure Helm chart)
+    ##
+    enabled: false
+    ## @param global.yeti.servicePort Yeti API service port (overrides `yeti.api.service.port`)
+    ##
+    servicePort:
+  ## @param global.existingPVC Existing claim for Timesketch persistent volume (overrides `persistent.name`)
+  ##
+  existingPVC: ""
+  ## @param global.storageClass StorageClass for the Timesketch persistent volume (overrides `persistent.storageClass`)
+  ##
+  storageClass: ""
+## @section HashR image configuration
+##
+image:
+  ## @param image.repository HashR image repository
+  ##
+  repository: us-docker.pkg.dev/osdfir-registry/hashr/release/hashr
+  ## @param image.pullPolicy HashR image pull policy
+  ## ref https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+  ##
+  pullPolicy: IfNotPresent
+  ## @param image.tag Overrides the image tag whose default is the chart appVersion
+  ##
+  tag: latest
+  ## @param image.imagePullSecrets Specify secrets if pulling from a private repository
+  ## ref https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+## @section HashR Configuration Paramters
+##
+hashr:
+  ## @param hashr.schedule Sets the cronjob schedule for running HashR
+  ##
+  schedule: "*/3 * * * *"
+  ## @section Enable/Disable HashR importers
+  ##
+  importers:
+    ## List of importers: GCP,targz,windows,wsus,deb,rpm,zip,gcr,iso9660
+    ## @param hashr.importers.gcp Enables the GCP importer
+    ##
+    gcp: false
+    ## @param hashr.importers.targz Enables the tar.gz importer
+    ##
+    targz: false
+    ## @param hashr.importers.windows Enables the Windows importer
+    ##
+    windows: false
+    ## @param hashr.importers.wsus Enables the WSUS importer
+    ##
+    wsus: false
+    ## @param hashr.importers.rpm Enables the RPM importer
+    ##
+    rpm: false
+    ## @param hashr.importers.zip Enables the ZIP importer
+    ##
+    zip: false
+    ## @param hashr.importers.gcr Enables the GCR importer
+    ##
+    gcr: false
+    ## @param hashr.importers.iso9660 Enables the iso9660 importer
+    ##
+    iso9660: false
+    ## @param hashr.importers.deb Enables the DEB importer
+    ##
+    deb: true
+## Persistence Storage Parameters
+##
+persistence:
+  ## @param persistence.name Timesketch persistent volume name
+  ##
+  name: hashrvolume
+  ## @param persistence.size Timesketch persistent volume size
+  ##
+  size: 2Gi
+  ## @param persistence.storageClass PVC Storage Class for Timesketch volume
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ## ref https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/#using-dynamic-provisioning
+  ##
+  storageClass: ""
+  ## @param persistence.accessModes PVC Access Mode for Timesketch volume
+  ## Access mode may need to be updated based on the StorageClass
+  ## ref https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
+  ##
+  accessModes:
+    - ReadWriteOnce
+## @section Postgresql Configuration Parameters
+## IMPORTANT: Postgresql is deployed with Auth enabled by default
+## To see a full list of available values, run helm show values charts/postgresql*
+##
+postgresql:
+  ## @param postgresql.enabled Enables the Postgresql deployment
+  ##
+  enabled: true
+  ## @param postgresql.architecture PostgreSQL architecture (`standalone` or `replication`)
+  ##
+  architecture: standalone
+  ## PostgreSQL Authentication parameters
+  ##
+  auth:
+    ## @param postgresql.auth.username Name for a custom PostgreSQL user to create
+    ##
+    username: "postgres"
+    ## @param postgresql.auth.database Name for a custom PostgreSQL database to create (overrides `auth.database`)
+    ##
+    database: "hashr"
+  ## PostgreSQL Primary configuration parameters
+  ##
+  primary:
+    ## PostgreSQL Primary service configuration parameters
+    ##
+    service:
+      ## @param postgresql.primary.service.type PostgreSQL primary service type
+      ##
+      type: ClusterIP
+      ## @param postgresql.primary.service.ports.postgresql PostgreSQL primary service port
+      ##
+      ports:
+        postgresql: 5432
+    ## PostgreSQL Primary persistence configuration
+    ##
+    persistence:
+      ## @param postgresql.primary.persistence.size PostgreSQL Persistent Volume size
+      ##
+      size: 2Gi
+    ## PostgreSQL primary resource requests and limits
+    ## @param postgresql.primary.resources.limits The resources limits for the PostgreSQL primary containers
+    ## @param postgresql.primary.resources.requests.cpu The requested cpu for the PostgreSQL primary containers
+    ## @param postgresql.primary.resources.requests.memory The requested memory for the PostgreSQL primary containers
+    ##
+    resources:
+      ## Example:
+      ## limits:
+      ##    cpu: 500m
+      ##    memory: 1Gi
+      limits: {}
+      ## Example:
+      ## requests:
+      ##    cpu: 500m
+      ##    memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+


### PR DESCRIPTION
### Description of the change

This PR adds the first helm chart to support the [HashR](https://github.com/google/hashr) project in osdfir infrastructure.
* Uses a postgresql container as storage for HashR results
* Runs the HashR workload as a CronJob 
* Provides a data manager pod that allows to `kubectl cp` the necessary data into the storage volume.

### Applicable issues

- part of #25 

### Additional information

This is submitted as a draft PR for initial review before I continue to add charts for other supported HashR processors (e.g. iso9660, GCP, AWS, etc.)

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Newly added variables are documented in the values.yaml
- [x] Title of the pull request is descriptive
