### PR TITLE
Add Nginx deployment to Timesketch for when Ingress (loadbalancer) is deployed 

### DIFF
--- a/charts/timesketch/Chart.lock
+++ b/charts/timesketch/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 12.11.1
+  version: 15.3.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 18.0.4
+  version: 19.3.2
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts/
-  version: 2.14.1
-digest: sha256:61618477213c24891b3302842aaa337405c68fdf998586eadef3a2ed9e9e4c1c
-generated: "2023-09-19T23:25:01.27067547Z"
+  version: 2.20.0
+digest: sha256:3fbaef8755ed79056d10a0c93cf5d278a47bb5f55b9a98802922edef4faa0610
+generated: "2024-05-16T13:22:27.139681-07:00"

--- a/charts/timesketch/Chart.yaml
+++ b/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 1.0.2
+version: 1.0.3
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch
@@ -11,15 +11,15 @@ home: "https://timesketch.org/"
 dependencies:
 - condition: postgresql.enabled
   name: postgresql
-  version: 12.11.1
+  version: 15.3.2
   repository: https://charts.bitnami.com/bitnami
 - condition: redis.enabled
   name: redis
-  version: 18.0.4
+  version: 19.3.2
   repository: https://charts.bitnami.com/bitnami
 - condition: opensearch.enabled
   name: opensearch
-  version: 2.14.1
+  version: 2.20.0
   repository: https://opensearch-project.github.io/helm-charts/
 maintainers:
   - name: Open Source DFIR

--- a/charts/timesketch/README.md
+++ b/charts/timesketch/README.md
@@ -150,6 +150,22 @@ kubectl delete pvc -l release=my-release
 | `worker.tolerations`               | Tolerations for Timesketch worker pods assignment                         | `[]`    |
 | `worker.affinity`                  | Affinity for Timesketch worker pods assignment                            | `{}`    |
 
+### Timesketch Nginx Configuration
+
+| Name                              | Description                                                              | Value                |
+| --------------------------------- | ------------------------------------------------------------------------ | -------------------- |
+| `nginx.image.repository`          | Nginx image repository                                                   | `nginx`              |
+| `nginx.image.tag`                 | Nginx image tag                                                          | `1.25.5-alpine-slim` |
+| `nginx.image.pullPolicy`          | Nginx image pull policy                                                  | `Always`             |
+| `nginx.podSecurityContext`        | Holds pod-level security attributes and common nginx container settings  | `{}`                 |
+| `nginx.securityContext`           | Holds security configuration that will be applied to the nginx container | `{}`                 |
+| `nginx.resources.limits`          | The resources limits for the nginx container                             | `{}`                 |
+| `nginx.resources.requests.cpu`    | The requested cpu for the nginx container                                | `250m`               |
+| `nginx.resources.requests.memory` | The requested memory for the nginx container                             | `256Mi`              |
+| `nginx.nodeSelector`              | Node labels for Timesketch nginx pods assignment                         | `{}`                 |
+| `nginx.tolerations`               | Tolerations for Timesketch nginx pods assignment                         | `[]`                 |
+| `nginx.affinity`                  | Affinity for Timesketch nginx pods assignment                            | `{}`                 |
+
 ### Common Parameters
 
 | Name                              | Description                                                                                                                        | Value               |

--- a/charts/timesketch/templates/gcp/backendconfig.yaml
+++ b/charts/timesketch/templates/gcp/backendconfig.yaml
@@ -12,6 +12,6 @@ spec:
     healthyThreshold: 2
     unhealthyThreshold: 2
     type: HTTP
-    requestPath: /login/
-    port: 5000
+    requestPath: /healthz/
+    port: 80
 {{- end }}

--- a/charts/timesketch/templates/gcp/managedcertificate.yaml
+++ b/charts/timesketch/templates/gcp/managedcertificate.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.ingress.enabled) (eq .Values.ingress.className "gce") }}
+{{- if and (.Values.ingress.enabled) (.Values.ingress.gcp.managedCertificates) }}
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:

--- a/charts/timesketch/templates/ingress.yaml
+++ b/charts/timesketch/templates/ingress.yaml
@@ -37,3 +37,43 @@ spec:
       port:
         number: 80 # Should match the port used by the Service
 {{- end }}
+{{- if and .Values.ingress.enabled .Values.ingress.gcp.staticIPV6Name }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name:  {{ include "timesketch.fullname" . }}-ingress-ipv6
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "timesketch.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingressClassName: {{ .Values.ingress.className }}
+    {{- if .Values.ingress.gcp.managedCertificates }}
+    networking.gke.io/managed-certificates: {{ include "timesketch.fullname" . }}-managed-ssl
+    {{- end }}
+    {{- if (eq .Values.ingress.className "gce") }}
+    {{- if .Values.ingress.gcp.staticIPV6Name }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gcp.staticIPV6Name }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ include "timesketch.fullname" . }}-frontend-config
+    {{- else }}
+    {{- fail "A valied .Values.ingress.gcp.staticIPV6Name entry is required when using the GCE Ingress" }}
+    {{- end }}
+    {{- end }}
+spec:
+  rules:
+    - host: {{ required "A valid .Values.ingress.host entry is required!" .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "timesketch.fullname" . }}-nginx
+                port:
+                  number: 80
+  defaultBackend:
+    service:
+      name: {{ include "timesketch.fullname" . }}-nginx # Name of the Service targeted by the Ingress
+      port:
+        number: 80 # Should match the port used by the Service
+{{- end }}

--- a/charts/timesketch/templates/ingress.yaml
+++ b/charts/timesketch/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "timesketch.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress.className }}
+    kubernetes.io/ingressClassName: {{ .Values.ingress.className }}
     {{- if .Values.ingress.gcp.managedCertificates }}
     networking.gke.io/managed-certificates: {{ include "timesketch.fullname" . }}-managed-ssl
     {{- end }}
@@ -28,48 +28,12 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "timesketch.fullname" . }}
+                name: {{ include "timesketch.fullname" . }}-nginx
                 port:
-                  number: {{ include "timesketch.service.port" . }}
+                  number: 80
   defaultBackend:
     service:
-      name: {{ include "timesketch.fullname" . }} # Name of the Service targeted by the Ingress
+      name: {{ include "timesketch.fullname" . }}-nginx # Name of the Service targeted by the Ingress
       port:
-        number: {{ include "timesketch.service.port" . }} # Should match the port used by the Service
-{{- end }}
-{{- if and .Values.ingress.enabled .Values.ingress.gcp.staticIPV6Name }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name:  {{ include "timesketch.fullname" . }}-ingress-ipv6
-  namespace: {{ .Release.Namespace | quote }}
-  labels:
-    {{- include "timesketch.labels" . | nindent 4 }}
-  annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress.className }}
-    {{- if .Values.ingress.gcp.managedCertificates }}
-    networking.gke.io/managed-certificates: {{ include "timesketch.fullname" . }}-managed-ssl
-    {{- end }}
-    {{- if (eq .Values.ingress.className "gce") }}
-    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gcp.staticIPV6Name }}
-    networking.gke.io/v1beta1.FrontendConfig: {{ include "timesketch.fullname" . }}-frontend-config
-    {{- end }}
-spec:
-  rules:
-    - host: {{ required "A valid .Values.ingress.host entry is required!" .Values.ingress.host }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "timesketch.fullname" . }}
-                port:
-                  number: {{ include "timesketch.service.port" . }}
-  defaultBackend:
-    service:
-      name: {{ include "timesketch.fullname" . }} # Name of the Service targeted by the Ingress
-      port:
-        number: {{ include "timesketch.service.port" . }} # Should match the port used by the Service
+        number: 80 # Should match the port used by the Service
 {{- end }}

--- a/charts/timesketch/templates/nginx-configmap.yaml
+++ b/charts/timesketch/templates/nginx-configmap.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "timesketch.fullname" . }}-nginx-configmap
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "timesketch.labels" . | nindent 4 }}
+data:
+  default.conf: |
+    server {
+        listen 80;
+        listen [::]:80;
+        client_max_body_size 0m;
+        location / {
+            proxy_buffer_size 128k;
+            proxy_buffers 4 256k;
+            proxy_busy_buffers_size 256k;
+            proxy_pass http://{{ include "timesketch.fullname" . }}:5000/;
+            proxy_read_timeout 120s;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+        location /healthz {
+            return 200;
+        }
+    }
+{{- end }}

--- a/charts/timesketch/templates/nginx-deployment.yaml
+++ b/charts/timesketch/templates/nginx-deployment.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name:  {{ include "timesketch.fullname" . }}-nginx
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: nginx
+    {{- include "timesketch.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: nginx
+      {{- include "timesketch.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: nginx
+        {{- include "timesketch.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "timesketch.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.nginx.podSecurityContext | nindent 8 }}
+      containers:
+        - name: nginx
+          securityContext:
+              {{- toYaml .Values.nginx.securityContext | nindent 12 }}
+          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              name: nginx-config
+              readOnly: true
+          ports:
+            - containerPort: 80
+          resources:
+            {{- toYaml .Values.nginx.resources | nindent 12 }}
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: {{ include "timesketch.fullname" . }}-nginx-configmap
+      {{- with .Values.nginx.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nginx.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nginx.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/timesketch/templates/nginx-service.yaml
+++ b/charts/timesketch/templates/nginx-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "timesketch.fullname" . }}-nginx
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "timesketch.labels" . | nindent 4 }}
+  {{- if and (.Values.ingress.enabled) ( eq .Values.ingress.className "gce") }}
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"ports": {"80":"{{ include "timesketch.fullname" . }}-backend-config"}}'
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app.kubernetes.io/component: nginx
+    {{- include "timesketch.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/timesketch/templates/service.yaml
+++ b/charts/timesketch/templates/service.yaml
@@ -5,11 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "timesketch.labels" . | nindent 4 }}
-  {{- if and (.Values.ingress.enabled) ( eq .Values.ingress.className "gce") }}
-  annotations:
-    cloud.google.com/neg: '{"ingress": true}'
-    cloud.google.com/backend-config: '{"ports": {"5000":"{{ include "timesketch.fullname" . }}-backend-config"}}'
-  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/timesketch/values.yaml
+++ b/charts/timesketch/values.yaml
@@ -178,7 +178,7 @@ nginx:
     ##
     repository: nginx
     ## @param nginx.image.tag Nginx image tag
-    ## 
+    ##
     tag: 1.25.5-alpine-slim
     ## @param nginx.image.pullPolicy Nginx image pull policy
     ##

--- a/charts/timesketch/values.yaml
+++ b/charts/timesketch/values.yaml
@@ -168,6 +168,66 @@ worker:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ##
   affinity: {}
+## @section Timesketch Nginx Configuration
+##
+nginx:
+  ##  Nginx image configuration
+  ##
+  image:
+    ## @param nginx.image.repository Nginx image repository
+    ##
+    repository: nginx
+    ## @param nginx.image.tag Nginx image tag
+    ## 
+    tag: 1.25.5-alpine-slim
+    ## @param nginx.image.pullPolicy Nginx image pull policy
+    ##
+    pullPolicy: Always
+  ## @param nginx.podSecurityContext Holds pod-level security attributes and common nginx container settings
+  ## Some fields are also present in container.securityContext. Field values of container.securityContext take precedence over field values of PodSecurityContext
+  ## ref https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podsecuritycontext-v1-core
+  ## e.g.
+  ## fsgroup: 2000
+  ##
+  podSecurityContext: {}
+  ## @param nginx.securityContext Holds security configuration that will be applied to the nginx container
+  ## Some fields are present in both SecurityContext and PodSecurityContext. When both are set, the values in SecurityContext take precedence
+  ## ref https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#securitycontext-v1-core
+  ## e.g.
+  ## capabilities
+  ##   drop:
+  ##   - ALL
+  ## readOnlyRootFilesystem: true
+  ## runAsNonRoot: true
+  ## runAsUser: 1000
+  ##
+  securityContext: {}
+  ## Timesketch Nginx resource requests and limits
+  ## @param nginx.resources.limits The resources limits for the nginx container
+  ## @param nginx.resources.requests.cpu The requested cpu for the nginx container
+  ## @param nginx.resources.requests.memory The requested memory for the nginx container
+  ##
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 500m
+    ##    memory: 1Gi
+    limits: {}
+    requests:
+      cpu: 250m
+      memory: 256Mi
+  ## @param nginx.nodeSelector Node labels for Timesketch nginx pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## @param nginx.tolerations Tolerations for Timesketch nginx pods assignment
+  ## ref https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  ##
+  tolerations: []
+  ## @param nginx.affinity Affinity for Timesketch nginx pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
 ## @section Common Parameters
 ##
 ## Service Account Parameters


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

Adds an NGINX deployment when Timesketch ingress is deployed. This fixes issues with configuring OIDC and Timesketch needing additional proxy headers for it all to work. 

This PR also updates the Helm dependency charts to the latest versions

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Newly added variables are documented in the values.yaml
- [x] Title of the pull request is descriptive
