### PR TITLE
Update alias for Turbinia monitoring

### DIFF
--- a/charts/turbinia/Chart.lock
+++ b/charts/turbinia/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 60.3.0
-digest: sha256:334ec3bbd6ba4d0698fb31d685919dfc6ad32c4d07e014cdf4c9931f2d6195c8
-generated: "2024-06-24T16:11:29.64642-07:00"
+digest: sha256:4541a72c66cf8ea1bf728dabc3cdabecb0013e04ac4568babc0f82fb59470c58
+generated: "2024-07-15T13:19:48.514639-07:00"

--- a/charts/turbinia/Chart.yaml
+++ b/charts/turbinia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: turbinia
-version: 1.0.9
+version: 1.1.0
 description: A Helm chart for Turbinia Kubernetes deployments.
 keywords:
 - turbinia
@@ -23,9 +23,9 @@ dependencies:
   name: dfdewey
   repository: https://google.github.io/osdfir-infrastructure/
   version: 1.0.0
-- condition: kubePrometheus.deployKubePrometheus
+- condition: monitoring.deployKubePrometheus
   name: kube-prometheus-stack
-  alias: kubePrometheus
+  alias: monitoring
   repository: https://prometheus-community.github.io/helm-charts
   version: 60.3.0
 maintainers:

--- a/charts/turbinia/README.md
+++ b/charts/turbinia/README.md
@@ -378,17 +378,17 @@ kubectl delete pvc -l release=my-release
 ### Third Party Configuration
 
 
-### kubePrometheus configuration parameters
+### Monitoring configuration parameters
 
-| Name                                                                               | Description                                                                                                                                 | Value   |
-| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `kubePrometheus.deployKubePrometheus`                                              | Deploy kube-prometheus-stack as a subchart. For production environments, it is best practice to deploy this chart separately.               | `false` |
-| `kubePrometheus.kubeScheduler.enabled`                                             | Component scraping kube scheduler. Disabled by default due to lack of Prometheus endpoint access for managed K8s clusters (e.g. GKE, EKS).  | `false` |
-| `kubePrometheus.kubeControllerManager.enabled`                                     | Component scraping kube controller. Disabled by default due to lack of Prometheus endpoint access for managed K8s clusters (e.g. GKE, EKS). | `false` |
-| `kubePrometheus.coreDns.enabled`                                                   | Component scraping core dns. Disabled by default in favor of kube dns.                                                                      | `false` |
-| `kubePrometheus.kubeProxy.enabled`                                                 | Component scraping kube proxy. Disabled by default due to lack of Prometheus endpoint access for managed K8s clusters (e.g. GKE, EKS).      | `false` |
-| `kubePrometheus.kubeDns.enabled`                                                   | Component scraping kube dns.                                                                                                                | `true`  |
-| `kubePrometheus.prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues` | Disable so that custom servicemonitors can be created and monitored                                                                         | `false` |
+| Name                                                                           | Description                                                                                                                                 | Value   |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `monitoring.deployKubePrometheus`                                              | Deploy kube-prometheus-stack as a subchart. For production environments, it is best practice to deploy this chart separately.               | `true`  |
+| `monitoring.kubeScheduler.enabled`                                             | Component scraping kube scheduler. Disabled by default due to lack of Prometheus endpoint access for managed K8s clusters (e.g. GKE, EKS).  | `false` |
+| `monitoring.kubeControllerManager.enabled`                                     | Component scraping kube controller. Disabled by default due to lack of Prometheus endpoint access for managed K8s clusters (e.g. GKE, EKS). | `false` |
+| `monitoring.coreDns.enabled`                                                   | Component scraping core dns. Disabled by default in favor of kube dns.                                                                      | `false` |
+| `monitoring.kubeProxy.enabled`                                                 | Component scraping kube proxy. Disabled by default due to lack of Prometheus endpoint access for managed K8s clusters (e.g. GKE, EKS).      | `false` |
+| `monitoring.kubeDns.enabled`                                                   | Component scraping kube dns.                                                                                                                | `true`  |
+| `monitoring.prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues` | Disable so that custom servicemonitors can be created and monitored                                                                         | `false` |
 
 ### Redis configuration parameters
 

--- a/charts/turbinia/values.yaml
+++ b/charts/turbinia/values.yaml
@@ -601,33 +601,34 @@ dfdewey:
         memory: 512Mi
 ## @section Third Party Configuration
 ##
-## @section kubePrometheus configuration parameters
+## @section Monitoring configuration parameters
+## IMPORTANT: Turbinia utilizes the kube-prometheus-stack for monitoring. This includes Prometheus, Grafana, and Alertmanager.
 ##
-kubePrometheus:
-  ## @param kubePrometheus.deployKubePrometheus Deploy kube-prometheus-stack as a subchart. For production environments, it is best practice to deploy this chart separately.
+monitoring:
+  ## @param monitoring.deployKubePrometheus Deploy kube-prometheus-stack as a subchart. For production environments, it is best practice to deploy this chart separately.
   ##
-  deployKubePrometheus: false
-  ## @param kubePrometheus.kubeScheduler.enabled Component scraping kube scheduler. Disabled by default due to lack of Prometheus endpoint access for managed K8s clusters (e.g. GKE, EKS).
+  deployKubePrometheus: true
+  ## @param monitoring.kubeScheduler.enabled Component scraping kube scheduler. Disabled by default due to lack of Prometheus endpoint access for managed K8s clusters (e.g. GKE, EKS).
   ##
   kubeScheduler:
     enabled: false
-  ## @param kubePrometheus.kubeControllerManager.enabled Component scraping kube controller. Disabled by default due to lack of Prometheus endpoint access for managed K8s clusters (e.g. GKE, EKS).
+  ## @param monitoring.kubeControllerManager.enabled Component scraping kube controller. Disabled by default due to lack of Prometheus endpoint access for managed K8s clusters (e.g. GKE, EKS).
   ##
   kubeControllerManager:
     enabled: false
-  ## @param kubePrometheus.coreDns.enabled Component scraping core dns. Disabled by default in favor of kube dns.
+  ## @param monitoring.coreDns.enabled Component scraping core dns. Disabled by default in favor of kube dns.
   ##
   coreDns:
     enabled: false
-  ## @param kubePrometheus.kubeProxy.enabled Component scraping kube proxy. Disabled by default due to lack of Prometheus endpoint access for managed K8s clusters (e.g. GKE, EKS).
+  ## @param monitoring.kubeProxy.enabled Component scraping kube proxy. Disabled by default due to lack of Prometheus endpoint access for managed K8s clusters (e.g. GKE, EKS).
   ##
   kubeProxy:
     enabled: false
-  ## @param kubePrometheus.kubeDns.enabled Component scraping kube dns.
+  ## @param monitoring.kubeDns.enabled Component scraping kube dns.
   ##
   kubeDns:
     enabled: true
-  ## @param kubePrometheus.prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues Disable so that custom servicemonitors can be created and monitored
+  ## @param monitoring.prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues Disable so that custom servicemonitors can be created and monitored
   ##
   prometheus:
     prometheusSpec:


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

<!-- Describe what the change does. -->

The `kubePrometheus` alias complains due to it being set to the service account name and the service account name not wanting uppercase characters so changing the alias to `monitoring` instead

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Newly added variables are documented in the values.yaml
- [x] Title of the pull request is descriptive
