### PR TITLE
charts/timesketch Add ability to provide existing config through ConfigMap and update docs around config updates

### DIFF
--- a/charts/timesketch/Chart.yaml
+++ b/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 1.0.6
+version: 1.0.7
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/timesketch/README.md
+++ b/charts/timesketch/README.md
@@ -362,7 +362,7 @@ of the volume that backs the underlying PersistentVolume. See [here](https://kub
 
 This section outlines how to deploy and manage Timesketch configuration files within OSDFIR infrastructure. There are three primary methods:
 
-1. Using Default Configurations
+1. **Using Default Configurations**
 
     If you don't provide your own Timesketch config files during deployment,
     the Timesketch deployment will automatically retrieve the latest default configs
@@ -370,7 +370,7 @@ This section outlines how to deploy and manage Timesketch configuration files wi
 
     > **NOTE:**  When using the default method, you cannot update the Timesketch config files directly.
 
-2. Embedding Timesketch configs in the Helm Chart
+2. **Embedding Timesketch configs in the Helm Chart**
 
     To customize Timesketch with your own config files and include them directly in the Helm chart deployment, follow these steps:
 
@@ -412,7 +412,7 @@ This section outlines how to deploy and manage Timesketch configuration files wi
         This will automatically apply the updated config changes and restart the Timesketch deployment so the changes can be picked up.
 
 
-3. Managing Timesketch configs externally
+3. **Managing Timesketch configs externally**
 
     For more advanced configuration management, you can manage Timesketch config
     files independently of the Helm chart:

--- a/charts/timesketch/README.md
+++ b/charts/timesketch/README.md
@@ -357,6 +357,101 @@ image tag to `latest` and increasing persistent volume size of an existing volum
 to 10 Terabytes. Note that existing data will not be deleted and instead triggers an expansion
 of the volume that backs the underlying PersistentVolume. See [here](https://kubernetes.io/docs/concepts/storage/persistent-volumes/).
 
+### Managing and updating Timesketch configs
+
+This section outlines how to deploy and manage Timesketch configuration files within OSDFIR infrastructure. There are three primary methods:
+
+1. Using Default Configurations
+
+    If you don't provide your own Timesketch config files during deployment,
+    the Timesketch deployment will automatically retrieve the latest default configs
+    from the Timesketch Github repository. This method requires no further action from you.
+
+    > **NOTE:**  When using the default method, you cannot update the Timesketch config files directly.
+
+2. Embedding Timesketch configs in the Helm Chart
+
+    To customize Timesketch with your own config files and include them directly in the Helm chart deployment, follow these steps:
+
+    1. Download and Extract the Helm chart:
+
+        ```console
+        helm pull osdfir-charts/timesketch --untar
+        cd timesketch/
+        ```
+
+    2. Download the default Timesketch configs:
+
+        ```console
+        ./tools/download-timesketch-configs.sh
+        ```
+
+        This script downloads the default Timesketch configuration files to the `config/` directory within the extracted Helm chart directory.
+
+    3. Modify config files then deploy the Helm chart:
+
+        ```console
+        helm install my-release ../timesketch 
+        ```
+
+        > **NOTE**: The Helm chart checks the path specified in `config.override` for existing config files. By default this path is set to `configs/` within the Helm chart directory.
+
+    To update configs changes using this method:
+
+    1. Modify Configuration Files
+
+        Make the necessary changes to your configuration files in the `config/` directory.
+
+    2. Upgrade the Helm Release:
+
+        ```console
+        helm upgrade my-release ../timesketch
+        ```
+
+        This will automatically apply the updated config changes and restart the Timesketch deployment so the changes can be picked up.
+
+
+3. Managing Timesketch configs externally
+
+    For more advanced configuration management, you can manage Timesketch config
+    files independently of the Helm chart:
+
+    1. Prepare your Config Files:
+
+        Organize all the Timesketch configuration files in a directory with your
+        desired customizations.
+
+    2. Create a ConfigMap:
+
+        ```console
+        kubectl create configmap timesketch-configs --from-file=./my-configs/
+        ```
+
+        Replace `./my-configs/` with the actual path to your configuration files.
+
+    3. Install or Upgrade the Helm Chart:
+
+        ```console
+        helm install my-release osdfir-charts/timesketch --set config.existingConfigMap="timesketch-configs"
+        ```
+
+        This command instructs the Helm chart to use the `timesketch-configs` ConfigMap for
+        Timesketch's config files.
+
+    To update the config changes using this method:
+
+    1. Update the ConfigMap:
+
+        ```console
+        kubectl create configmap timesketch-configs --from-file=./my-configs/ --dry-run -o yaml | kubectl replace -f -
+        ```
+
+    2. Restart the Timesketch deployment to apply the new configs
+
+        ```console
+        kubectl rollout restart deployment -l app.kubernetes.io/name=timesketch
+        ```
+
 ### Upgrade Timesketch Database Schema
 
 From time to time, a Timesketch release requires a manual database upgrade if

--- a/charts/timesketch/README.md
+++ b/charts/timesketch/README.md
@@ -173,6 +173,7 @@ kubectl delete pvc -l release=my-release
 | Name                                                 | Description                                                                                                                           | Value       |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | `config.override`                                    | Overrides the default Timesketch configs to instead use a user specified directory if present on the root directory of the Helm chart | `configs/*` |
+| `config.existingConfigMap`                           | Use an existing ConfigMap as the default Timesketch config.                                                                           | `""`        |
 | `config.createUser`                                  | Creates a default Timesketch user that can be used to login to Timesketch after deployment                                            | `true`      |
 | `config.oidc.enabled`                                | Enables Timesketch OIDC authentication (currently only supports Google OIDC)                                                          | `false`     |
 | `config.oidc.existingSecret`                         | Existing secret with the client ID, secret and cookie secret                                                                          | `""`        |

--- a/charts/timesketch/templates/_helpers.tpl
+++ b/charts/timesketch/templates/_helpers.tpl
@@ -172,3 +172,11 @@ Timesketch service port
 {{- printf "%s-access-list" (include "timesketch.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "timesketch.configmap" -}}
+{{- if .Values.config.existingConfigMap -}}
+{{- .Values.config.existingConfigMap -}}
+{{- else -}}
+{{- include "timesketch.fullname" . }}-configmap
+{{- end -}}
+{{- end -}}

--- a/charts/timesketch/templates/init-configmap.yaml
+++ b/charts/timesketch/templates/init-configmap.yaml
@@ -16,6 +16,7 @@ data:
 
     if [ $(ls /tmp/timesketch/ | wc -l) -gt 0 ]; then
       echo "Using existing configuration files provided."
+      ls /tmp/timesketch
       cp /tmp/timesketch/* /etc/timesketch/
     else
       echo -n "* Fetching configuration files.." 

--- a/charts/timesketch/templates/web-deployment.yaml
+++ b/charts/timesketch/templates/web-deployment.yaml
@@ -85,7 +85,7 @@ spec:
           emptyDir: {}
         - name: uploaded-configs
           configMap:
-            name: {{ include "timesketch.fullname" . }}-configmap
+            name: {{ include "timesketch.configmap" . }}
             optional: true
         {{- if .Values.config.oidc.authenticatedEmailsFile.enabled }}
         - name: authenticated-emails

--- a/charts/timesketch/templates/worker-deployment.yaml
+++ b/charts/timesketch/templates/worker-deployment.yaml
@@ -74,7 +74,7 @@ spec:
           emptyDir: {}
         - name: uploaded-configs
           configMap:
-            name: {{ include "timesketch.fullname" . }}-configmap
+            name: {{ include "timesketch.configmap" . }}
             optional: true
         {{- if .Values.config.oidc.authenticatedEmailsFile.enabled }}
         - name: authenticated-emails

--- a/charts/timesketch/values.yaml
+++ b/charts/timesketch/values.yaml
@@ -70,6 +70,11 @@ config:
   ## script packaged along with this Helm chart.
   ##
   override: configs/*
+  ## @param config.existingConfigMap Use an existing ConfigMap as the default Timesketch config.
+  ## Please ensure that the ConfigMap has been created prior to deployment
+  ## (e.g. kubectl create configmap timesketch-configs --from-file=timesketch-configs/)
+  ##
+  existingConfigMap: ""
   ## @param config.createUser Creates a default Timesketch user that can be used to login to Timesketch after deployment
   ##
   createUser: true


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

<!-- Describe what the change does. -->

Adds documentation around the various ways of updating Timesketch configs and allows configs to be provided outside of the Helm chart through a `ConfigMap`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Newly added variables are documented in the values.yaml
- [x] Title of the pull request is descriptive
