### PR TITLE
Pin arangodb to 3.11

### DIFF
--- a/charts/osdfir-infrastructure/README.md
+++ b/charts/osdfir-infrastructure/README.md
@@ -364,7 +364,7 @@ kubectl delete pvc -l release=my-release
 | `yeti.redis.master.resources.requests`  | The requested resources for the Redis master containers                                      | `{}`        |
 | `yeti.arangodb.image.repository`        | Yeti arangodb image repository                                                               | `arangodb`  |
 | `yeti.arangodb.image.pullPolicy`        | Yeti image pull policy                                                                       | `Always`    |
-| `yeti.arangodb.image.tag`               | Overrides the image tag whose default is the chart appVersion                                | `latest`    |
+| `yeti.arangodb.image.tag`               | Overrides the image tag whose default is the chart appVersion                                | `3.11`      |
 | `yeti.arangodb.resources.limits`        | Resource limits for the arangodb container                                                   | `{}`        |
 | `yeti.arangodb.resources.requests`      | Requested resources for the arangodb container                                               | `{}`        |
 

--- a/charts/osdfir-infrastructure/values.yaml
+++ b/charts/osdfir-infrastructure/values.yaml
@@ -794,7 +794,7 @@ yeti:
       pullPolicy: Always
       ## @param yeti.arangodb.image.tag Overrides the image tag whose default is the chart appVersion
       ##
-      tag: latest
+      tag: 3.11
     ## Yeti arangodb resource requests and limits
     ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
     ## @param yeti.arangodb.resources.limits Resource limits for the arangodb container


### PR DESCRIPTION
Arangodb 3.12 introduces a problematic licensing change - 3.11 is safe to use for the forseeable future.