### PR TITLE
charts/timesketch charts/openrelik Fix pvc storageclassname setting

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: timesketch
   repository: file://charts/timesketch
-  version: 2.0.0
+  version: 2.1.0
 - name: yeti
   repository: file://charts/yeti
   version: 2.0.1
 - name: openrelik
   repository: file://charts/openrelik
-  version: 2.0.0
-digest: sha256:49457af91c360353222e0d3ca9af71f92c0b22dac128f82c0780b1d743b495cd
-generated: "2025-02-10T10:59:57.997332-08:00"
+  version: 2.1.0
+digest: sha256:fc3b10d3b35d6c8d863c7b15bdf399cf4c7f934a67a55e613a0da3fe8744c90c
+generated: "2025-02-25T16:01:11.819386-08:00"

--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 2.1.0
 - name: yeti
   repository: file://charts/yeti
-  version: 2.0.1
+  version: 2.1.0
 - name: openrelik
   repository: file://charts/openrelik
   version: 2.1.0
-digest: sha256:fc3b10d3b35d6c8d863c7b15bdf399cf4c7f934a67a55e613a0da3fe8744c90c
-generated: "2025-02-25T16:01:11.819386-08:00"
+digest: sha256:3f89233a518829a86984452261ec2dbb6a6b7f4b8e64985b66f56b19218818c6
+generated: "2025-02-27T09:27:24.657697-08:00"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.1.0
+version: 2.2.0
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch
@@ -14,7 +14,7 @@ dependencies:
 - condition: global.timesketch.enabled
   name: timesketch
   repository: file://charts/timesketch
-  version: 2.0.0
+  version: 2.1.0
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti
@@ -22,7 +22,7 @@ dependencies:
 - condition: global.openrelik.enabled
   name: openrelik
   repository: file://charts/openrelik
-  version: 2.0.0
+  version: 2.1.0
 maintainers:
   - name: Open Source DFIR
     email: osdfir-maintainers@googlegroups.com

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti
-  version: 2.0.1
+  version: 2.1.0
 - condition: global.openrelik.enabled
   name: openrelik
   repository: file://charts/openrelik

--- a/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: openrelik
-version: 2.0.0
+version: 2.1.0
 description: A Helm chart for Openrelik Kubernetes deployments.
 keywords:
 - openrelik

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/pvc.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}-openrelikvolume-claim
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  {{- if .Values.persistence.storageClass -}}
+  {{- if .Values.persistence.storageClass }}
   storageClassName: {{ .Values.persistence.storageClass }}
   {{- end }}
   accessModes:

--- a/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 2.0.0
+version: 2.1.0
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/pvc.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}-timesketchvolume-claim
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  {{- if .Values.persistence.storageClass -}}
+  {{- if .Values.persistence.storageClass }}
   storageClassName: {{ .Values.persistence.storageClass }}
   {{- end }}
   accessModes:

--- a/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: yeti
-version: 2.0.1
+version: 2.1.0
 description: A Helm chart for Yeti Kubernetes deployments.
 keywords:
 - yeti

--- a/charts/osdfir-infrastructure/charts/yeti/values.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/values.yaml
@@ -33,7 +33,7 @@ frontend:
     pullPolicy: IfNotPresent
     ## @param frontend.image.tag Overrides the image tag whose default is the chart appVersion
     ##
-    tag: latest
+    tag: 2.2.2
   ## Yeti frontend resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param frontend.resources.limits Resource limits for the frontend container
@@ -65,7 +65,7 @@ api:
     pullPolicy: IfNotPresent
     ## @param api.image.tag Overrides the image tag whose default is the chart appVersion
     ##
-    tag: latest
+    tag: 2.2.2
   ## Yeti api resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param api.resources.limits Resource limits for the API container
@@ -97,7 +97,7 @@ tasks:
     pullPolicy: IfNotPresent
     ## @param tasks.image.tag Overrides the image tag whose default is the chart appVersion
     ##
-    tag: latest
+    tag: 2.2.2
   ## Yeti tasks resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param tasks.resources.limits Resource limits for the tasks container


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

<!-- Describe what the change does. -->

Change `{{- if .Values.persistence.storageClass -}}` to `{{- if .Values.persistence.storageClass }}` as the extra `-` was causing the PVC storage class name to be removed when specified (e.g. for filestore).

Pin yeti to 2.2.2 until we find a new method for passing Yeti API Key from stdout (as the option to create it before along with the user was removed)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Newly added variables are documented in the values.yaml
- [X] Title of the pull request is descriptive
