### PR TITLE
Update host in notes

### DIFF
--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.2.0
+version: 2.2.1
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/NOTES.txt
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/NOTES.txt
@@ -10,7 +10,7 @@ To learn more about the release, try:
 To connect to the OpenRelik URL:
   $ kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ .Release.Name }}-openrelik 8711:8711
   $ kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ .Release.Name }}-openrelik-api 8710:8710
-  $ echo "Visit http://127.0.0.1:8711 to access OpenRelik UI through port-forwarding"
+  $ echo "Visit http://localhost:8711 to access OpenRelik UI through port-forwarding"
 
 Login to OpenRelik with the User `openrelik`. To get your password run:
   $ kubectl get secret --namespace {{ .Release.Namespace }} {{ .Release.Name }}-openrelik-secret -o jsonpath="{.data.openrelik-user}" | base64 -d


### PR DESCRIPTION


### Description of the change

Changes link for openrelik host to connect to after install.   Otherwise you get authentication errors at the API server with a default install similar to this:

```
INFO:     127.0.0.1:56704 - "GET /api/v1/users/me/ HTTP/1.1" 401 Unauthorized
```

### Applicable issues

n/a

### Additional information


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Newly added variables are documented in the values.yaml
- [X] Title of the pull request is descriptive
