### PR TITLE
Update release.yml permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   packages: write
   pages: write
+  contents: write
 
 jobs:
   release:


### PR DESCRIPTION
Github actions release.yml failing to create new release due to `403 Resource not accessible by integration`. I believe we are missing content permissions needed to do this based on this [stack overflow discussion](https://stackoverflow.com/questions/75995802/resource-not-accessible-by-integration-github-action-fails-for-pushed-commit)