### PR TITLE
Allow existing PVC for Timesketch and OpenRelik

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: timesketch
   repository: file://charts/timesketch
-  version: 2.1.1
+  version: 2.1.2
 - name: yeti
   repository: file://charts/yeti
   version: 2.1.0
 - name: openrelik
   repository: file://charts/openrelik
-  version: 2.1.1
+  version: 2.1.2
 - name: grr
   repository: file://charts/grr
   version: 2.2.0
-digest: sha256:5e6ff181c3599aedf88b32a577e3ba188608130df5bdc111bdb8e064a6aacca7
-generated: "2025-04-24T16:23:14.305088557Z"
+digest: sha256:5b08161942d98d6f7faab0fb12d497ef1c8e5962bc0874edc6cd89f84548ef00
+generated: "2025-04-24T13:15:20.670128-07:00"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: global.timesketch.enabled
   name: timesketch
   repository: file://charts/timesketch
-  version: 2.1.1
+  version: 2.1.2
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti
@@ -22,7 +22,7 @@ dependencies:
 - condition: global.openrelik.enabled
   name: openrelik
   repository: file://charts/openrelik
-  version: 2.1.1
+  version: 2.1.2
 - condition: global.grr.enabled
   name: grr
   repository: file://charts/grr

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.2.6
+version: 2.2.7
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: openrelik
-version: 2.1.1
+version: 2.1.2
 description: A Helm chart for Openrelik Kubernetes deployments.
 keywords:
 - openrelik

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/api-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/api-deployment.yaml
@@ -65,8 +65,11 @@ spec:
       volumes:
         - name: openrelikvolume
           persistentVolumeClaim:
+            {{- if .Values.persistence.existingPVC }}
+            claimName: {{ .Values.persistence.existingPVC }}
+            {{- else }}
             claimName: {{ .Release.Name }}-openrelikvolume-claim
-            readOnly: false
+            {{- end }}
         - name: settings-config
           configMap:
             name: {{ .Release.Name }}-openrelik-configmap

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/api-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/api-deployment.yaml
@@ -70,6 +70,7 @@ spec:
             {{- else }}
             claimName: {{ .Release.Name }}-openrelikvolume-claim
             {{- end }}
+            readOnly: false
         - name: settings-config
           configMap:
             name: {{ .Release.Name }}-openrelik-configmap

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/frontend-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/frontend-deployment.yaml
@@ -50,5 +50,9 @@ spec:
       volumes:
         - name: openrelikvolume
           persistentVolumeClaim:
+            {{- if .Values.persistence.existingPVC }}
+            claimName: {{ .Values.persistence.existingPVC }}
+            {{- else }}
             claimName: {{ .Release.Name }}-openrelikvolume-claim
+            {{- end }}
             readOnly: false

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/mediator-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/mediator-deployment.yaml
@@ -54,8 +54,11 @@ spec:
       volumes:
         - name: openrelikvolume
           persistentVolumeClaim:
+            {{- if .Values.persistence.existingPVC }}
+            claimName: {{ .Values.persistence.existingPVC }}
+            {{- else }}
             claimName: {{ .Release.Name }}-openrelikvolume-claim
-            readOnly: false
+            {{- end }}
         - name: settings-config
           configMap:
             name: {{ .Release.Name }}-openrelik-configmap

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/mediator-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/mediator-deployment.yaml
@@ -59,6 +59,7 @@ spec:
             {{- else }}
             claimName: {{ .Release.Name }}-openrelikvolume-claim
             {{- end }}
+            readOnly: false
         - name: settings-config
           configMap:
             name: {{ .Release.Name }}-openrelik-configmap

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/pvc.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.persistence.existingPVC }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -14,3 +15,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
@@ -56,4 +56,5 @@ spec:
             {{- else }}
             claimName: {{ $.Release.Name }}-openrelikvolume-claim
             {{- end }}
+            readOnly: false
 {{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
@@ -51,6 +51,9 @@ spec:
       volumes:
         - name: openrelikvolume
           persistentVolumeClaim:
+            {{- if $.Values.persistence.existingPVC }}
+            claimName: {{ $.Values.persistence.existingPVC }}
+            {{- else }}
             claimName: {{ $.Release.Name }}-openrelikvolume-claim
-            readOnly: false
+            {{- end }}
 {{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/values.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/values.yaml
@@ -222,6 +222,9 @@ config:
 ## Persistence Storage Parameters
 ##
 persistence:
+  ## @param persistence.existingPVC Specify an existing PVC to use for the OpenRelik volume
+  ##
+  existingPVC: "" 
   ## @param persistence.size OpenRelik persistent volume size
   ##
   size: 2Gi

--- a/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 2.1.1
+version: 2.1.2
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/pvc.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.persistence.existingPVC }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -14,3 +15,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment.yaml
@@ -62,7 +62,11 @@ spec:
       volumes:
         - name: timesketchvolume
           persistentVolumeClaim:
+            {{- if .Values.persistence.existingPVC }}
+            claimName: {{ .Values.persistence.existingPVC }}
+            {{- else }}
             claimName: {{ .Release.Name }}-timesketchvolume-claim
+            {{- end }}
             readOnly: false
         - name: init-timesketch
           configMap:

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/worker-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/worker-deployment.yaml
@@ -56,7 +56,11 @@ spec:
       volumes:
         - name: timesketchvolume
           persistentVolumeClaim:
+            {{- if .Values.persistence.existingPVC }}
+            claimName: {{ .Values.persistence.existingPVC }}
+            {{- else }}
             claimName: {{ .Release.Name }}-timesketchvolume-claim
+            {{- end }}
             readOnly: false
         - name: init-timesketch
           configMap:

--- a/charts/osdfir-infrastructure/charts/timesketch/values.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/values.yaml
@@ -144,6 +144,9 @@ nginx:
 ## Persistence Storage Parameters
 ##
 persistence:
+  ## @param persistence.existingPVC Specify an existing PVC to use for the Timesketch volume
+  ##
+  existingPVC: ""
   ## @param persistence.size Timesketch persistent volume size
   ##
   size: 2Gi


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

<!-- Describe what the change does. -->
Allow existing PVC for Timesketch and OpenRelik. This allows a given user to specify a existing PVC if they created one outside of the Helm chart

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Newly added variables are documented in the values.yaml
- [X] Title of the pull request is descriptive
