### PR TITLE
Update secret handling, add nodeselector, openrelik nbd and yara container, and other small fixes

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: timesketch
   repository: file://charts/timesketch
-  version: 2.1.3
+  version: 2.1.4
 - name: yeti
   repository: file://charts/yeti
-  version: 2.1.0
+  version: 2.1.1
 - name: openrelik
   repository: file://charts/openrelik
-  version: 2.1.2
+  version: 2.1.3
 - name: grr
   repository: file://charts/grr
   version: 2.2.0
 - name: hashr
   repository: file://charts/hashr
   version: 2.0.0
-digest: sha256:d53ca2f2084ea1ed5b8fffd319499721a696228b4618c8300738085722f54521
-generated: "2025-05-12T20:38:33.883680087Z"
+digest: sha256:542f8df2a4ceb2d58416ee0a6aedecd73c298af7735ad796b88b6777212818a4
+generated: "2025-05-28T13:25:08.971259-07:00"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.2.9
+version: 2.3.0
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -14,15 +14,15 @@ dependencies:
 - condition: global.timesketch.enabled
   name: timesketch
   repository: file://charts/timesketch
-  version: 2.1.3
+  version: 2.1.4
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti
-  version: 2.1.0
+  version: 2.1.1
 - condition: global.openrelik.enabled
   name: openrelik
   repository: file://charts/openrelik
-  version: 2.1.2
+  version: 2.1.3
 - condition: global.grr.enabled
   name: grr
   repository: file://charts/grr

--- a/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: openrelik
-version: 2.1.2
+version: 2.1.3
 description: A Helm chart for Openrelik Kubernetes deployments.
 keywords:
 - openrelik

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/_initContainer.tpl
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/_initContainer.tpl
@@ -4,7 +4,7 @@ OIDC when enabled due to the changes having to be in settings.toml
 */}}
 {{- define "openrelik.initContainer" -}}
 - name: init-openrelik
-  image: ubuntu
+  image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
   command: ['sh', '-c', '/init/init-openrelik.sh']
   {{- if and .Values.config.oidc.enabled .Values.config.oidc.existingSecret }} 
   env:

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/_initContainerWorker.tpl
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/_initContainerWorker.tpl
@@ -1,0 +1,30 @@
+{{/*
+Init Container for when a OpenRelik worker requires the nbd module loaded into
+the underlying node to allow for processing of qcow2 disk images.
+*/}}
+{{- define "openrelik.initContainerWorker" -}}
+- name: init-nbd-module
+  image: {{ .Values.config.initWorkerNbd.image }}
+  command: ['sh']
+  args:
+    - "-c"
+    - |
+      if ! lsmod | grep -q "^nbd "; then
+        echo "nbd module not loaded. Attempting to load..."
+        if modprobe nbd; then
+          echo "nbd module loaded successfully."
+        else
+          echo "Error: Failed to load nbd module." >&2
+          exit 1
+        fi
+      else
+        echo "nbd module already loaded."
+      fi
+  securityContext:
+    privileged: true
+    runAsUser: 0
+  volumeMounts:
+    - mountPath: /lib/modules
+      name: modules
+      readOnly: true
+{{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/api-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/api-deployment.yaml
@@ -88,3 +88,7 @@ spec:
               path: authenticated-emails-list
             secretName: {{ include "openrelik.oidc.authenticatedemails" . }}
         {{- end }}
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/api-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/api-deployment.yaml
@@ -28,7 +28,7 @@ spec:
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           command: ["/bin/sh", "-c", "uvicorn main:app --proxy-headers --forwarded-allow-ips '*' --workers 1 --host 0.0.0.0 --port 8710"]
-          {{- if not .Release.IsUpgrade }}
+          {{- if and (not .Release.IsUpgrade) (.Values.config.createUser) }}
           lifecycle:
             postStart:
               exec:

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
     
     # This should be set to the URL of your frontend server.
     {{- if .Values.global.ingress.openRelikFrontendHost }}
-    allowed_origins = ["https://{{ .Values.global.ingress.openRelikFrontendHost }}", "https://{{ .Values.global.ingress.openRelikFrontendHost }}/"] 
+    allowed_origins = ["https://{{ .Values.global.ingress.openRelikFrontendHost }}"] 
     {{- else }}
     allowed_origins = ["http://localhost:8711"]
     {{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
@@ -73,11 +73,7 @@ data:
     # Allow anyone (who is authenitcated) to access the server.
     # Note: If a workspace_domain is set then the public_access is limited to that domain.
     # WARNING: This allows anyone to login to your server!
-    {{ if .Values.config.oidc.workspaceDomain -}}
-    public_access = true
-    {{ else -}}
     public_access = false
-    {{ end -}}
 
     [ui]
     # data_types that will be rendered using unescaped HTML in a sandboxed iframe in the

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
@@ -73,7 +73,11 @@ data:
     # Allow anyone (who is authenitcated) to access the server.
     # Note: If a workspace_domain is set then the public_access is limited to that domain.
     # WARNING: This allows anyone to login to your server!
+    {{ if .Values.config.oidc.workspaceDomain -}}
+    public_access = true
+    {{ else -}}
     public_access = false
+    {{ end -}}
 
     [ui]
     # data_types that will be rendered using unescaped HTML in a sandboxed iframe in the

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
     
     # This should be set to the URL of your frontend server.
     {{- if .Values.global.ingress.openRelikFrontendHost }}
-    allowed_origins = ["https://{{ .Values.global.ingress.openRelikFrontendHost }}"] 
+    allowed_origins = ["https://{{ .Values.global.ingress.openRelikFrontendHost }}/"] 
     {{- else }}
     allowed_origins = ["http://localhost:8711"]
     {{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
     
     # This should be set to the URL of your frontend server.
     {{- if .Values.global.ingress.openRelikFrontendHost }}
-    allowed_origins = ["https://{{ .Values.global.ingress.openRelikFrontendHost }}"] 
+    allowed_origins = ["https://{{ .Values.global.ingress.openRelikFrontendHost }}", "https://{{ .Values.global.ingress.openRelikFrontendHost }}/"] 
     {{- else }}
     allowed_origins = ["http://localhost:8711"]
     {{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
     
     # This should be set to the URL of your frontend server.
     {{- if .Values.global.ingress.openRelikFrontendHost }}
-    allowed_origins = ["https://{{ .Values.global.ingress.openRelikFrontendHost }}/"] 
+    allowed_origins = ["https://{{ .Values.global.ingress.openRelikFrontendHost }}"] 
     {{- else }}
     allowed_origins = ["http://localhost:8711"]
     {{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
@@ -65,7 +65,7 @@ data:
 
     # Restrict logins from a Google Workspace domain.
     # Empty value = any domain, including gmail.com
-    workspace_domain = ""
+    workspace_domain = "{{ .Values.config.oidc.workspaceDomain }}"
 
     # Allow only these users (email address) to access the server.
     allowlist = ["<REPLACE_WITH_USERNAME>@gmail.com"]
@@ -81,12 +81,3 @@ data:
     allowed_data_types_preview = [
         "openrelik:hayabusa:html_report"
     ]
-
-    # Enable cloud features such as adding cloud disks.
-    # This requires your OpenRelik installation to run on cloud VMs.
-    [cloud.gcp]
-    name = "gcp"
-    display_name = "Google Cloud Platform"
-    project_name = ""
-    zone = ""
-    enabled = false

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/frontend-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/frontend-deployment.yaml
@@ -56,3 +56,7 @@ spec:
             claimName: {{ .Release.Name }}-openrelikvolume-claim
             {{- end }}
             readOnly: false
+      {{- with .Values.frontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/api-backendconfig.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/api-backendconfig.yaml
@@ -1,4 +1,4 @@
-{{- if (and (.Values.global.ingress.enabled) (eq .Values.global.ingress.className "gce")) }}
+{{- if (eq .Values.global.ingress.className "gce") }}
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/api-backendconfig.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/api-backendconfig.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   timeoutSec: 300
   healthCheck:
-    checkIntervalSec: 300
+    checkIntervalSec: 60
     timeoutSec: 5
     healthyThreshold: 2
     unhealthyThreshold: 2

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/frontend-backendconfig.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/frontend-backendconfig.yaml
@@ -1,4 +1,4 @@
-{{- if (eq .Values.global.ingress.className "gce")) }}
+{{- if (eq .Values.global.ingress.className "gce") }}
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/frontend-backendconfig.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/frontend-backendconfig.yaml
@@ -1,4 +1,4 @@
-{{- if (and (.Values.global.ingress.enabled) (eq .Values.global.ingress.className "gce")) }}
+{{- if (eq .Values.global.ingress.className "gce")) }}
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/mediator-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/mediator-deployment.yaml
@@ -63,3 +63,7 @@ spec:
         - name: settings-config
           configMap:
             name: {{ .Release.Name }}-openrelik-configmap
+      {{- with .Values.mediator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/metrics-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/metrics-deployment.yaml
@@ -39,3 +39,7 @@ spec:
             - containerPort: 8080
           resources:
             {{- toYaml .Values.metrics.resources | nindent 12 }}
+      {{- with .Values.metrics.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/postgres/postgres-statefulset.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/postgres/postgres-statefulset.yaml
@@ -69,6 +69,10 @@ spec:
       volumes:
         - name: emptydir
           emptyDir: {}
+      {{- with .Values.postgresql.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/prometheus/prometheus-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/prometheus/prometheus-deployment.yaml
@@ -38,3 +38,7 @@ spec:
           configMap:
             name: {{ .Release.Name }}-openrelik-prometheus-configmap
             defaultMode: 420
+      {{- with .Values.prometheus.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/redis/redis-statefulset.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/redis/redis-statefulset.yaml
@@ -58,6 +58,10 @@ spec:
             - containerPort: 6379
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/secret.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.config.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,3 +23,4 @@ data:
   redis-user: {{ $redisUser | b64enc | quote }}
   redis-url: {{ printf "redis://default:%s@%s-openrelik-redis:6379" $redisUser .Release.Name | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: {{ $.Release.Name }}-{{ .name }}
 spec:
-  replicas: 1
+  replicas: {{ .replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: worker

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
@@ -57,4 +57,8 @@ spec:
             claimName: {{ $.Release.Name }}-openrelikvolume-claim
             {{- end }}
             readOnly: false
+      {{- with .nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
@@ -50,7 +50,7 @@ spec:
           volumeMounts:
             - mountPath: /mnt/openrelikvolume
               name: openrelikvolume
-            {{- if and .privileged .mountHostDevices }}
+            {{- if .privileged }}
             - mountPath: /dev
               name: dev
               readOnly: true
@@ -68,7 +68,7 @@ spec:
             claimName: {{ $.Release.Name }}-openrelikvolume-claim
             {{- end }}
             readOnly: false
-        {{- if and .privileged .mountHostDevices }}
+        {{- if .privileged }}
         - name: dev
           hostPath:
             path: /dev

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app.kubernetes.io/component: worker
     spec:
+      {{- if and .privileged $.Values.config.initWorkerNbd.enabled }}
+      initContainers:
+      {{- include "openrelik.initContainerWorker" $ | nindent 8 }}
+      {{- end }}
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
@@ -46,7 +50,7 @@ spec:
           volumeMounts:
             - mountPath: /mnt/openrelikvolume
               name: openrelikvolume
-            {{- if .mountHostDevices }}
+            {{- if and .privileged .mountHostDevices }}
             - mountPath: /dev
               name: dev
               readOnly: true
@@ -64,10 +68,15 @@ spec:
             claimName: {{ $.Release.Name }}-openrelikvolume-claim
             {{- end }}
             readOnly: false
-        {{- if .mountHostDevices }}
+        {{- if and .privileged .mountHostDevices }}
         - name: dev
           hostPath:
             path: /dev
+        {{- if $.Values.config.initWorkerNbd.enabled }}
+        - name: modules
+          hostPath:
+            path: /lib/modules
+        {{- end }}
         {{- end }}
       {{- with .nodeSelector }}
       nodeSelector:

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/worker-deployment.yaml
@@ -22,6 +22,8 @@ spec:
           image: {{ .image | quote }}
           imagePullPolicy: "IfNotPresent"
           command: ["/bin/sh", "-c", "{{ .command }}"]
+          securityContext:
+            privileged: {{ .privileged }}
           env:
           {{- if and (eq .name "openrelik-worker-timesketch") $.Values.global.timesketch.enabled }}
             - name: TIMESKETCH_SERVER_URL
@@ -44,6 +46,11 @@ spec:
           volumeMounts:
             - mountPath: /mnt/openrelikvolume
               name: openrelikvolume
+            {{- if .mountHostDevices }}
+            - mountPath: /dev
+              name: dev
+              readOnly: true
+            {{- end }}
           {{- if .resources }}
           resources:
             {{- toYaml .resources | nindent 12 }}
@@ -57,6 +64,11 @@ spec:
             claimName: {{ $.Release.Name }}-openrelikvolume-claim
             {{- end }}
             readOnly: false
+        {{- if .mountHostDevices }}
+        - name: dev
+          hostPath:
+            path: /dev
+        {{- end }}
       {{- with .nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/osdfir-infrastructure/charts/openrelik/values.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/values.yaml
@@ -197,6 +197,9 @@ config:
   ## Secret name must follow the naming convention of {{ .Release.Name }}-openrelik-secret
   ##
   existingSecret: false
+  ## @param config.createUser Create a default `openrelik` user.
+  ##
+  createUser: true
   ## OpenRelik OIDC configuration
   ##
   oidc:

--- a/charts/osdfir-infrastructure/charts/openrelik/values.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/values.yaml
@@ -37,7 +37,7 @@ frontend:
     pullPolicy: IfNotPresent
     ## @param frontend.image.tag Overrides the image tag whose default is the chart appVersion
     ##
-    tag: "2024.12.12"
+    tag: "0.6.0"
   ## OpenRelik frontend resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param frontend.resources.limits Resource limits for the frontend container
@@ -69,7 +69,7 @@ api:
     pullPolicy: IfNotPresent
     ## @param api.image.tag Overrides the image tag whose default is the chart appVersion
     ##
-    tag: "2024.12.12"
+    tag: "0.6.0"
   ## OpenRelik api resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param api.resources.limits Resource limits for the API container
@@ -101,7 +101,7 @@ mediator:
     pullPolicy: IfNotPresent
     ## @param mediator.image.tag Overrides the image tag whose default is the chart appVersion
     ##
-    tag: "2024.12.12"
+    tag: "0.6.0"
   ## OpenRelik mediator resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param mediator.resources.limits Resource limits for the Mediator container
@@ -133,7 +133,7 @@ metrics:
     pullPolicy: IfNotPresent
     ## @param metrics.image.tag Overrides the image tag whose default is the chart appVersion
     ##
-    tag: "2024.12.12"
+    tag: "0.6.0"
   ## OpenRelik metrics resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param metrics.resources.limits Resource limits for the Metrics container
@@ -170,36 +170,46 @@ metrics:
 ##
 workers:
 - name: openrelik-worker-strings
-  image: ghcr.io/openrelik/openrelik-worker-strings:2024.11.27
+  image: ghcr.io/openrelik/openrelik-worker-strings:0.2.1
   command: celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-strings
+  privileged: false
+  mountHostDevices: false
   replicas: 1
   env: {}
   resources: {}
   nodeSelector: {}
 - name: openrelik-worker-plaso
-  image: ghcr.io/openrelik/openrelik-worker-plaso:2024.11.27
+  image: ghcr.io/openrelik/openrelik-worker-plaso:0.4.0
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-plaso"
+  privileged: false
+  mountHostDevices: false
   replicas: 1
   env: {}
   resources: {}
   nodeSelector: {}
 - name: openrelik-worker-extraction
-  image: ghcr.io/openrelik/openrelik-worker-extraction:2024.11.27
+  image: ghcr.io/openrelik/openrelik-worker-extraction:0.4.0
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-extraction"
+  privileged: false
+  mountHostDevices: false
   replicas: 1
   env: {}
   resources: {}
   nodeSelector: {}
 - name: openrelik-worker-analyzer-config
-  image: ghcr.io/openrelik/openrelik-worker-analyzer-config:2024.11.27
+  image: ghcr.io/openrelik/openrelik-worker-analyzer-config:0.2.0
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-analyzer-config"
+  privileged: false
+  mountHostDevices: false
   replicas: 1
   env: {}
   resources: {}
   nodeSelector: {}
 - name: openrelik-worker-hayabusa
-  image: ghcr.io/openrelik/openrelik-worker-hayabusa:2024.11.27
+  image: ghcr.io/openrelik/openrelik-worker-hayabusa:0.3.0
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-hayabusa"
+  privileged: false
+  mountHostDevices: false
   replicas: 1
   env: {}
   resources: {}
@@ -208,8 +218,10 @@ workers:
 ## variables through Helm.
 ##
 - name: openrelik-worker-timesketch
-  image: ghcr.io/openrelik/openrelik-worker-timesketch:2024.11.27
+  image: ghcr.io/openrelik/openrelik-worker-timesketch:0.3.0
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-timesketch"
+  privileged: false
+  mountHostDevices: false
   replicas: 1
   env: {}
   resources: {}

--- a/charts/osdfir-infrastructure/charts/openrelik/values.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/values.yaml
@@ -173,7 +173,6 @@ workers:
   image: ghcr.io/openrelik/openrelik-worker-strings:0.2.1
   command: celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-strings
   privileged: false
-  mountHostDevices: false
   replicas: 1
   env: {}
   resources: {}
@@ -182,7 +181,6 @@ workers:
   image: ghcr.io/openrelik/openrelik-worker-plaso:0.4.0
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-plaso"
   privileged: false
-  mountHostDevices: false
   replicas: 1
   env: {}
   resources: {}
@@ -191,7 +189,6 @@ workers:
   image: ghcr.io/openrelik/openrelik-worker-extraction:0.4.0
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-extraction"
   privileged: false
-  mountHostDevices: false
   replicas: 1
   env: {}
   resources: {}
@@ -200,7 +197,6 @@ workers:
   image: ghcr.io/openrelik/openrelik-worker-analyzer-config:0.2.0
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-analyzer-config"
   privileged: false
-  mountHostDevices: false
   replicas: 1
   env: {}
   resources: {}
@@ -209,7 +205,6 @@ workers:
   image: ghcr.io/openrelik/openrelik-worker-hayabusa:0.3.0
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-hayabusa"
   privileged: false
-  mountHostDevices: false
   replicas: 1
   env: {}
   resources: {}
@@ -217,10 +212,11 @@ workers:
 - name: openrelik-worker-yara
   image: ghcr.io/openrelik/openrelik-worker-yara:latest
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-yara"
-  privileged: false
-  mountHostDevices: false
+  privileged: true
   replicas: 1
   env: {}
+  resources: {}
+  nodeSelector: {}
 ## When deployed via the OSDFIR Infrastructure chart, the Timesketch Worker automatically receives its required environment 
 ## variables through Helm.
 ##
@@ -228,7 +224,6 @@ workers:
   image: ghcr.io/openrelik/openrelik-worker-timesketch:0.3.0
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-timesketch"
   privileged: false
-  mountHostDevices: false
   replicas: 1
   env: {}
   resources: {}

--- a/charts/osdfir-infrastructure/charts/openrelik/values.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/values.yaml
@@ -53,6 +53,9 @@ frontend:
     ##    cpu: 500m
     ##    memory: 1Gi
     requests: {}
+  ## @param frontend.nodeSelector Node labels for Frontend pods assignment
+  ##
+  nodeSelector: {}
 ## @section OpenRelik API configuration
 ##
 api:
@@ -82,6 +85,9 @@ api:
     ##    cpu: 500m
     ##    memory: 1Gi
     requests: {}
+  ## @param api.nodeSelector Node labels for API pods assignment
+  ##
+  nodeSelector: {}
 ## @section OpenRelik Mediator configuration
 ##
 mediator:
@@ -111,6 +117,9 @@ mediator:
     ##    cpu: 500m
     ##    memory: 1Gi
     requests: {}
+  ## @param mediator.nodeSelector Node labels for Mediator pods assignment
+  ##
+  nodeSelector: {}
 ## @section OpenRelik Metrics configuration
 ##
 metrics:
@@ -140,6 +149,9 @@ metrics:
     ##    cpu: 500m
     ##    memory: 1Gi
     requests: {}
+  ## @param metrics.nodeSelector Node labels for Metrics pods assignment
+  ##
+  nodeSelector: {}
 ## @section OpenRelik Worker Configurations
 ## By default, resources are not set to allow the Helm chart to remain flexible in various deployments.
 ## To set resources, remove {} and replace with the provided resources
@@ -162,26 +174,31 @@ workers:
   command: celery --app=src.app worker --task-events --concurrency=4 --loglevel=INFO -Q openrelik-worker-strings
   env: {}
   resources: {}
+  nodeSelector: {}
 - name: openrelik-worker-plaso
   image: ghcr.io/openrelik/openrelik-worker-plaso:2024.11.27
   command: "celery --app=src.app worker --task-events --concurrency=2 --loglevel=INFO -Q openrelik-worker-plaso"
   env: {}
   resources: {}
+  nodeSelector: {}
 - name: openrelik-worker-extraction
   image: ghcr.io/openrelik/openrelik-worker-extraction:2024.11.27
   command: "celery --app=src.app worker --task-events --concurrency=2 --loglevel=INFO -Q openrelik-worker-extraction"
   env: {}
   resources: {}
+  nodeSelector: {}
 - name: openrelik-worker-analyzer-config
   image: ghcr.io/openrelik/openrelik-worker-analyzer-config:2024.11.27
   env: {}
   resources: {}
+  nodeSelector: {}
   command: "celery --app=src.app worker --task-events --concurrency=4 --loglevel=INFO -Q openrelik-worker-analyzer-config"
 - name: openrelik-worker-hayabusa
   image: ghcr.io/openrelik/openrelik-worker-hayabusa:2024.11.27
   command: "celery --app=src.app worker --task-events --concurrency=4 --loglevel=INFO -Q openrelik-worker-hayabusa"
   env: {}
   resources: {}
+  nodeSelector: {}
 ## When deployed via the OSDFIR Infrastructure chart, the Timesketch Worker automatically receives its required environment 
 ## variables through Helm.
 ##
@@ -190,6 +207,7 @@ workers:
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-timesketch"
   env: {}
   resources: {}
+  nodeSelector: {}
 ## @section OpenRelik Configuration Parameters
 ##
 config:
@@ -284,6 +302,9 @@ redis:
     ##    cpu: 500m
     ##    memory: 1Gi
     requests: {}
+  ## @param redis.nodeSelector Node labels for Redis pods assignment
+  ##
+  nodeSelector: {}
 ## @section Postgresql Configuration Parameters
 ##
 postgresql:
@@ -320,6 +341,9 @@ postgresql:
     requests:
       cpu: 250m
       memory: 256Mi
+  ## @param postgresql.nodeSelector Node labels for Postgresql pods assignment
+  ##
+  nodeSelector: {}
 ## @section Prometheus Configuration Parameters
 ##
 prometheus:
@@ -352,3 +376,6 @@ prometheus:
     ##    cpu: 500m
     ##    memory: 1Gi
     requests: {}
+  ## @param prometheus.nodeSelector Node labels for Prometheus pods assignment
+  ##
+  nodeSelector: {}

--- a/charts/osdfir-infrastructure/charts/openrelik/values.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/values.yaml
@@ -171,31 +171,36 @@ metrics:
 workers:
 - name: openrelik-worker-strings
   image: ghcr.io/openrelik/openrelik-worker-strings:2024.11.27
-  command: celery --app=src.app worker --task-events --concurrency=4 --loglevel=INFO -Q openrelik-worker-strings
+  command: celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-strings
+  replicas: 1
   env: {}
   resources: {}
   nodeSelector: {}
 - name: openrelik-worker-plaso
   image: ghcr.io/openrelik/openrelik-worker-plaso:2024.11.27
-  command: "celery --app=src.app worker --task-events --concurrency=2 --loglevel=INFO -Q openrelik-worker-plaso"
+  command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-plaso"
+  replicas: 1
   env: {}
   resources: {}
   nodeSelector: {}
 - name: openrelik-worker-extraction
   image: ghcr.io/openrelik/openrelik-worker-extraction:2024.11.27
-  command: "celery --app=src.app worker --task-events --concurrency=2 --loglevel=INFO -Q openrelik-worker-extraction"
+  command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-extraction"
+  replicas: 1
   env: {}
   resources: {}
   nodeSelector: {}
 - name: openrelik-worker-analyzer-config
   image: ghcr.io/openrelik/openrelik-worker-analyzer-config:2024.11.27
+  command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-analyzer-config"
+  replicas: 1
   env: {}
   resources: {}
   nodeSelector: {}
-  command: "celery --app=src.app worker --task-events --concurrency=4 --loglevel=INFO -Q openrelik-worker-analyzer-config"
 - name: openrelik-worker-hayabusa
   image: ghcr.io/openrelik/openrelik-worker-hayabusa:2024.11.27
-  command: "celery --app=src.app worker --task-events --concurrency=4 --loglevel=INFO -Q openrelik-worker-hayabusa"
+  command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-hayabusa"
+  replicas: 1
   env: {}
   resources: {}
   nodeSelector: {}
@@ -205,6 +210,7 @@ workers:
 - name: openrelik-worker-timesketch
   image: ghcr.io/openrelik/openrelik-worker-timesketch:2024.11.27
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-timesketch"
+  replicas: 1
   env: {}
   resources: {}
   nodeSelector: {}

--- a/charts/osdfir-infrastructure/charts/openrelik/values.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/values.yaml
@@ -212,7 +212,7 @@ workers:
 - name: openrelik-worker-yara
   image: ghcr.io/openrelik/openrelik-worker-yara:latest
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-yara"
-  privileged: true
+  privileged: false
   replicas: 1
   env: {}
   resources: {}

--- a/charts/osdfir-infrastructure/charts/openrelik/values.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/values.yaml
@@ -214,6 +214,13 @@ workers:
   env: {}
   resources: {}
   nodeSelector: {}
+- name: openrelik-worker-yara
+  image: ghcr.io/openrelik/openrelik-worker-yara:latest
+  command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-yara"
+  privileged: false
+  mountHostDevices: false
+  replicas: 1
+  env: {}
 ## When deployed via the OSDFIR Infrastructure chart, the Timesketch Worker automatically receives its required environment 
 ## variables through Helm.
 ##
@@ -233,6 +240,17 @@ config:
   ## Secret name must follow the naming convention of {{ .Release.Name }}-openrelik-secret
   ##
   existingSecret: false
+  ## OpenRelik nbd init container configuration for OpenRelik containers that require the nbd module.
+  ## Only enable this container when you need to load the nbd kernel module to the underlying node.
+  ##
+  initWorkerNbd:
+    ## @param config.initWorkerNbd.enabled Whether to enable the nbd init container
+    ##
+    enabled: false
+    ## @param config.initWorkerNbd.image Container image with modprobe installed necessary
+    ## for loading the nbd module
+    ##
+    image: "us-central1-docker.pkg.dev/osdfir-registry/openrelik/openrelik-nbd:0.1.0"
   ## @param config.createUser Create a default `openrelik` user.
   ##
   createUser: true

--- a/charts/osdfir-infrastructure/charts/openrelik/values.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/values.yaml
@@ -193,6 +193,10 @@ workers:
 ## @section OpenRelik Configuration Parameters
 ##
 config:
+  ## @param config.existingSecret Use an existing secret as the OpenRelik secret.
+  ## Secret name must follow the naming convention of {{ .Release.Name }}-openrelik-secret
+  ##
+  existingSecret: false
   ## OpenRelik OIDC configuration
   ##
   oidc:
@@ -202,12 +206,15 @@ config:
     ## @param config.oidc.existingSecret Existing secret with the client ID, secret and cookie secret
     ##
     existingSecret: ""
+    ## @param config.oidc.workspaceDomain Restricts logins from a Google Workspace domain.
+    ##
+    workspaceDomain: ""
     ## Allowed emails files for OpenRelik OIDC
     ##
     authenticatedEmailsFile:
       ## @param config.oidc.authenticatedEmailsFile.enabled Enables email authentication
       ##
-      enabled: true
+      enabled: false
       ## @param config.oidc.authenticatedEmailsFile.existingSecret Existing secret with a list of emails
       ## e.g. kubectl create secret generic allowed-emails --from-file=authenticated-emails-list=allowed-emails.txt
       existingSecret: ""

--- a/charts/osdfir-infrastructure/charts/openrelik/values.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/values.yaml
@@ -212,7 +212,7 @@ workers:
 - name: openrelik-worker-yara
   image: ghcr.io/openrelik/openrelik-worker-yara:latest
   command: "celery --app=src.app worker --task-events --concurrency=1 --loglevel=INFO -Q openrelik-worker-yara"
-  privileged: false
+  privileged: true
   replicas: 1
   env: {}
   resources: {}

--- a/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 2.1.3
+version: 2.1.4
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/_initContainer.tpl
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/_initContainer.tpl
@@ -5,7 +5,7 @@ Worker pod upon startup.
 */}}
 {{- define "timesketch.initContainer" -}}
 - name: init-timesketch
-  image: alpine/git
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
   command: ['sh', '-c', '/init/init-timesketch.sh']
   env:
     - name: TIMESKETCH_SECRET

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/init-configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/init-configmap.yaml
@@ -28,6 +28,8 @@ data:
       echo "Copied configuration files."
     else
       echo "No existing configuration found. Fetching default configuration files from GitHub.."
+      echo "Installing git for cloning repo"
+      apt-get update && apt-get install git -y
       # Using a temporary directory for cloning
       TMP_CLONE_DIR=$(mktemp -d)
       # Try cloning the specific tag/branch first, fallback to master if it fails

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/opensearch/opensearch-statefulset.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/opensearch/opensearch-statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       {{- if .Values.opensearch.sysctlInit.enabled }}
       initContainers:
       - name: sysctl
-        image: "busybox:latest"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: "IfNotPresent"
         command:
         - sh
@@ -37,11 +37,10 @@ spec:
         securityContext:
           runAsUser: 0
           privileged: true
+      {{- end }}
       securityContext:
         fsGroup: 1000
         runAsUser: 1000
-        fsGroupChangePolicy: Always
-      {{- end }}
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/secret.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.config.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,3 +19,4 @@ data:
   postgres-user: {{ randAlphaNum 16 | b64enc | quote }}
   redis-user: {{ randAlphaNum 16 | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/osdfir-infrastructure/charts/timesketch/values.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/values.yaml
@@ -39,6 +39,10 @@ config:
   ## (e.g. kubectl create configmap timesketch-configs --from-file=timesketch-configs/)
   ##
   existingConfigMap: ""
+  ## @param config.existingSecret Use an existing secret as the Timesketch secret.
+  ## Secret name must follow the naming convention of {{ .Release.Name }}-timesketch-secret
+  ##
+  existingSecret: false
   ## @param config.createUser Creates a default Timesketch user that can be used to login to Timesketch after deployment
   ##
   createUser: true
@@ -56,7 +60,7 @@ config:
     authenticatedEmailsFile:
       ## @param config.oidc.authenticatedEmailsFile.enabled Enables email authentication
       ##
-      enabled: true
+      enabled: false
       ## @param config.oidc.authenticatedEmailsFile.existingSecret Existing secret with a list of emails
       ## e.g. kubectl create secret generic allowed-emails --from-file=authenticated-emails-list=allowed-emails.txt
       existingSecret: ""

--- a/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: yeti
-version: 2.1.0
+version: 2.1.1
 description: A Helm chart for Yeti Kubernetes deployments.
 keywords:
 - yeti

--- a/charts/osdfir-infrastructure/charts/yeti/templates/secret.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.config.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -16,3 +17,4 @@ data:
   yeti-arangodb: {{ randAlphaNum 16 | b64enc | quote }}
   yeti-api: {{ randNumeric 64 | lower | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/osdfir-infrastructure/charts/yeti/values.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/values.yaml
@@ -120,6 +120,10 @@ tasks:
 ## ref: https://github.com/yeti-platform/yeti/blob/main/yeti.conf.sample
 ##
 config:
+  ## @param config.existingSecret Use an existing secret as the Yeti secret.
+  ## Secret name must follow the naming convention of {{ .Release.Name }}-yeti-secret
+  ##
+  existingSecret: false
   ## Yeti OIDC configuration
   ##
   oidc:

--- a/charts/osdfir-infrastructure/templates/ingress-ipv6.yaml
+++ b/charts/osdfir-infrastructure/templates/ingress-ipv6.yaml
@@ -2,7 +2,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  {{- if .Values.global.ingress.overrideIngressName }}
+  name: {{ .Values.global.ingress.overrideIngressName }}-ipv6
+  {{- else }}
   name: {{ .Release.Name }}-osdfir-ingress-ipv6
+  {{- end }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "osdfir.labels" . | nindent 4 }}

--- a/charts/osdfir-infrastructure/templates/ingress-ipv6.yaml
+++ b/charts/osdfir-infrastructure/templates/ingress-ipv6.yaml
@@ -14,6 +14,8 @@ metadata:
     kubernetes.io/ingressClassName: {{ .Values.global.ingress.className }}
     {{- if .Values.global.ingress.gcp.managedCertificates }}
     networking.gke.io/managed-certificates: {{ .Release.Name }}-osdfir-managed-ssl
+    {{- else if .Values.global.ingress.gcp.existingManagedCertificates }}
+    networking.gke.io/managed-certificates: {{ .Values.global.ingress.gcp.existingManagedCertificates }} 
     {{- end }}
     {{- if .Values.global.ingress.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/charts/osdfir-infrastructure/templates/ingress.yaml
+++ b/charts/osdfir-infrastructure/templates/ingress.yaml
@@ -2,7 +2,11 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  {{- if .Values.global.ingress.overrideIngressName }}
+  name: {{ .Values.global.ingress.overrideIngressName }}
+  {{- else }}
   name: {{ .Release.Name }}-osdfir-ingress
+  {{- end }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "osdfir.labels" . | nindent 4 }}

--- a/charts/osdfir-infrastructure/templates/ingress.yaml
+++ b/charts/osdfir-infrastructure/templates/ingress.yaml
@@ -14,6 +14,8 @@ metadata:
     kubernetes.io/ingressClassName: {{ .Values.global.ingress.className }}
     {{- if .Values.global.ingress.gcp.managedCertificates }}
     networking.gke.io/managed-certificates: {{ .Release.Name }}-osdfir-managed-ssl
+    {{- else if .Values.global.ingress.gcp.existingManagedCertificates }}
+    networking.gke.io/managed-certificates: {{ .Values.global.ingress.gcp.existingManagedCertificates }} 
     {{- end }}
     {{- if .Values.global.ingress.certManager }}
     kubernetes.io/tls-acme: "true"

--- a/charts/osdfir-infrastructure/values.yaml
+++ b/charts/osdfir-infrastructure/values.yaml
@@ -39,6 +39,9 @@ global:
     ## @param global.ingress.enabled Enable the global loadbalancer for external access (only used in the main OSDFIR Infrastructure Helm chart)
     ##
     enabled: false
+    ## @param global.ingress.overrideIngressName Override the default loadbalancer name in case of multiple deployments
+    ##
+    overrideIngressName: ""
     ## @param global.ingress.timesketchHost Domain name Timesketch will be hosted under
     ##
     timesketchHost: ""

--- a/charts/osdfir-infrastructure/values.yaml
+++ b/charts/osdfir-infrastructure/values.yaml
@@ -67,10 +67,13 @@ global:
     ## GCP ingress configuration
     ##
     gcp:
-      ## @param global.ingress.gcp.managedCertificates Enabled GCP managed certificates for your domain
+      ## @param global.ingress.gcp.managedCertificates Enable automatic creation of GCP managed certificates for your domain
       ## ref https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs
       ##
       managedCertificates: false
+      ## @param global.ingress.gcp.existingManagedCertificates Specify an existing GCP certificate name
+      ##
+      existingManagedCertificates: ""
       ## @param global.ingress.gcp.staticIPName Name of the static IP address you reserved in GCP
       ## This is required when using "gce" in ingress.className
       ## ref https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address

--- a/extras/tools/nbd/Dockerfile
+++ b/extras/tools/nbd/Dockerfile
@@ -1,0 +1,15 @@
+# Use the official Docker Hub Ubuntu base image
+FROM ubuntu:24.04
+
+# Prevent needing to configure debian packages, stopping the setup of
+# the docker container.
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# Install poetry and any other dependency that your worker needs.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    kmod \
+    # Add your dependencies here
+    && rm -rf /var/lib/apt/lists/*
+
+# Default command if not run from docker-compose (and command being overidden)
+CMD ["sleep 3600"]


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change
* Add `nodeSelector` to OpenRelik pods to allow us to specify which nodes we want them on
* Add `replicas` to OpenRelik worker pods to allow for more pods, nodeselector, privileged option and mounting block storage for processing disks
* Allow an existing secret to be provided across Timesketch, OpenRelik, and Yeti to allow for non Helm managed releases (where Helm provides the rendered k8s files, but another tool manages the release e.g. skaffold, GCP cloud deploy)
  * Without this, `{{- if .Release.IsUpgrade }}` logic fails to evaluate as Helm is not managing the release and creates a new secret each time.
* Update ingress specification to allow for ingress name overrides to allow instead to expose each tool to its own LB for specific setups.
* Update OpenRelik healthcheck interval to lower number to fix HC being ready in time
* Add OpenRelik NBD InitContainer for workers that require nbd but the underlying node does not have it enabled yet
* Add OpenRelik yara worker to config
* Update InitContainer images and some other small fixes.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Newly added variables are documented in the values.yaml
- [X] Title of the pull request is descriptive
