### PR TITLE
Update Yeti to latest containers and fix integration with Timesketch

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: timesketch
   repository: file://charts/timesketch
-  version: 2.1.4
+  version: 2.2.0
 - name: yeti
   repository: file://charts/yeti
-  version: 2.1.1
+  version: 2.2.0
 - name: openrelik
   repository: file://charts/openrelik
   version: 2.1.4
@@ -14,5 +14,5 @@ dependencies:
 - name: hashr
   repository: file://charts/hashr
   version: 2.0.0
-digest: sha256:c23a77adc7817b4dbd5550f6df458d43229c80847940abd73231ee6d146094e6
-generated: "2025-07-14T08:40:24.876949-07:00"
+digest: sha256:5c04cb2bf6efe8b1d828809c88d6bdc4a8e294df2dc06085a0944565ebccedcf
+generated: "2025-07-14T14:37:17.025183-07:00"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.3.1
+version: 2.4.0
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch
@@ -14,11 +14,11 @@ dependencies:
 - condition: global.timesketch.enabled
   name: timesketch
   repository: file://charts/timesketch
-  version: 2.1.4
+  version: 2.2.0
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti
-  version: 2.1.1
+  version: 2.2.0
 - condition: global.openrelik.enabled
   name: openrelik
   repository: file://charts/openrelik

--- a/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 2.1.4
+version: 2.2.0
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/_initContainer.tpl
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/_initContainer.tpl
@@ -23,11 +23,11 @@ Worker pod upon startup.
         secretKeyRef:
           name: {{ .Release.Name }}-timesketch-secret
           key: postgres-user
-    {{- if .Values.global.yeti.enabled }}
+    {{- if and .Values.global.yeti.enabled .Values.global.yeti.apiKeySecret }}
     - name: YETI_API_KEY
       valueFrom:
         secretKeyRef:
-          name: {{ printf "%s-yeti-secret" .Release.Name }}
+          name: {{ .Values.global.yeti.apiKeySecret | quote }}
           key: "yeti-api"
     {{- end }}
     {{- if .Values.global.hashr.enabled }}

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/init-configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/init-configmap.yaml
@@ -85,7 +85,7 @@ data:
     {{- end }}
 
     # Yeti integration
-    {{- if .Values.global.yeti.enabled }}
+    {{- if and .Values.global.yeti.enabled .Values.global.yeti.apiKeySecret }}
     sed -i 's#^YETI_API_KEY =.*#YETI_API_KEY = "'$YETI_API_KEY'"#' timesketch.conf
     sed -i 's#^YETI_API_ROOT =.*#YETI_API_ROOT =  {{ printf "http://%s-yeti:9000/api/v2" .Release.Name | quote }}#' timesketch.conf
     {{- end }}

--- a/charts/osdfir-infrastructure/charts/timesketch/values.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/values.yaml
@@ -13,6 +13,11 @@ global:
     ## @param global.yeti.enabled Enables the Yeti deployment (only used in the main OSDFIR Infrastructure Helm chart)
     ##
     enabled: false
+    ## @param global.yeti.apiKeySecret Existing secret containing Yeti API Key.
+    ## Please ensure that the Secret has been created then re-deploy the Helm chart when integrating Yeti with Timesketch
+    ## (e.g. kubectl create secret generic yeti-api-secret --from-literal=yeti-api=${YETI_API_KEY})
+    ##
+    apiKeySecret: ""
   ingress:
     ## @param global.ingress.enabled Enable the global loadbalancer for external access (only used in the main OSDFIR Infrastructure Helm chart)
     ##
@@ -29,7 +34,7 @@ image:
   pullPolicy: IfNotPresent
   ## @param image.tag Overrides the image tag whose default is the chart appVersion
   ##
-  tag: "20250408"
+  tag: "20250708"
 ## @section Timesketch Configuration Parameters
 ## ref: https://github.com/google/timesketch/blob/master/data/timesketch.conf
 ##

--- a/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: yeti
-version: 2.1.1
+version: 2.2.0
 description: A Helm chart for Yeti Kubernetes deployments.
 keywords:
 - yeti

--- a/charts/osdfir-infrastructure/charts/yeti/templates/_env.tpl
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/_env.tpl
@@ -19,7 +19,10 @@ Worker pod upon startup.
 - name: YETI_ARANGODB_USERNAME
   value: root
 - name: YETI_AUTH_SECRET_KEY
-  value: {{ randAlphaNum 32 | quote }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-yeti-secret 
+      key: yeti-secret
 - name: YETI_AUTH_ALGORITHM
   value: HS256
 - name: YETI_AUTH_ACCESS_TOKEN_EXPIRE_MINUTES
@@ -58,11 +61,6 @@ Worker pod upon startup.
     secretKeyRef:
       name: {{ .Release.Name }}-yeti-secret 
       key: yeti-arangodb
-- name: YETI_API_KEY
-  valueFrom:
-    secretKeyRef:
-      name: {{ .Release.Name }}-yeti-secret 
-      key: yeti-api
 {{- if .Values.global.timesketch.enabled }}
 - name: YETI_TIMESKETCH_ENDPOINT
   value: {{ printf "http://%s-timesketch:5000" .Release.Name | quote }}

--- a/charts/osdfir-infrastructure/charts/yeti/templates/beats-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/beats-deployment.yaml
@@ -1,37 +1,31 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-yeti-api
+  name: {{ .Release.Name }}-yeti-beats
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/component: api
+    app.kubernetes.io/component: beats
     {{- include "yeti.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: api
+      app.kubernetes.io/component: beats
       {{- include "yeti.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: api
+        app.kubernetes.io/component: beats
         {{- include "yeti.selectorLabels" . | nindent 8 }}
     spec:
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
       containers:
-        - name: api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
-          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
-          command: ["sh", "-c", "/docker-entrypoint.sh webserver"]
-          {{- if and (not .Release.IsUpgrade) .Values.config.createUser }}
-          lifecycle:
-            postStart:
-              exec:
-                command: ["sh", "-c", "uv run python yetictl/cli.py create-user yeti $YETI_USER_PASSWORD --admin"]
-          {{- end }}
+        - name: beats
+          image: "{{ .Values.tasks.image.repository }}:{{ .Values.tasks.image.tag }}"
+          imagePullPolicy: {{ .Values.tasks.image.pullPolicy }}
+          command: ["sh", "-c", "/docker-entrypoint.sh tasks-beat"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -42,11 +36,9 @@ spec:
               type: RuntimeDefault
           env:
           {{- include "yeti.envs" . | nindent 12 }}
-          ports:
-            - containerPort: 8000
           resources:
-            {{- toYaml .Values.api.resources | nindent 12 }}
-      {{- with .Values.api.nodeSelector }}
+            {{- toYaml .Values.beats.resources | nindent 12 }}
+      {{- with .Values.beats.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/osdfir-infrastructure/charts/yeti/templates/bloomcheck-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/bloomcheck-deployment.yaml
@@ -1,37 +1,35 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-yeti-api
+  name: {{ .Release.Name }}-yeti-bloomcheck
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/component: api
+    app.kubernetes.io/component: bloomcheck
     {{- include "yeti.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: api
+      app.kubernetes.io/component: bloomcheck
       {{- include "yeti.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: api
+        app.kubernetes.io/component: bloomcheck
         {{- include "yeti.selectorLabels" . | nindent 8 }}
     spec:
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
       containers:
-        - name: api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
-          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
-          command: ["sh", "-c", "/docker-entrypoint.sh webserver"]
-          {{- if and (not .Release.IsUpgrade) .Values.config.createUser }}
-          lifecycle:
-            postStart:
-              exec:
-                command: ["sh", "-c", "uv run python yetictl/cli.py create-user yeti $YETI_USER_PASSWORD --admin"]
-          {{- end }}
+        - name: bloomcheck
+          image: "{{ .Values.bloomcheck.image.repository }}:{{ .Values.bloomcheck.image.tag }}"
+          imagePullPolicy: {{ .Values.bloomcheck.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              mkdir -p /opt/yeti/bloomfilters && \
+              /app/bloomcheck -serve /opt/yeti/bloomfilters
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -42,11 +40,9 @@ spec:
               type: RuntimeDefault
           env:
           {{- include "yeti.envs" . | nindent 12 }}
-          ports:
-            - containerPort: 8000
           resources:
-            {{- toYaml .Values.api.resources | nindent 12 }}
-      {{- with .Values.api.nodeSelector }}
+            {{- toYaml .Values.bloomcheck.resources | nindent 12 }}
+      {{- with .Values.bloomcheck.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/osdfir-infrastructure/charts/yeti/templates/events-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/events-deployment.yaml
@@ -1,37 +1,31 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-yeti-api
+  name: {{ .Release.Name }}-yeti-events
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app.kubernetes.io/component: api
+    app.kubernetes.io/component: events
     {{- include "yeti.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: api
+      app.kubernetes.io/component: events
       {{- include "yeti.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: api
+        app.kubernetes.io/component: events
         {{- include "yeti.selectorLabels" . | nindent 8 }}
     spec:
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
       containers:
-        - name: api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
-          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
-          command: ["sh", "-c", "/docker-entrypoint.sh webserver"]
-          {{- if and (not .Release.IsUpgrade) .Values.config.createUser }}
-          lifecycle:
-            postStart:
-              exec:
-                command: ["sh", "-c", "uv run python yetictl/cli.py create-user yeti $YETI_USER_PASSWORD --admin"]
-          {{- end }}
+        - name: events
+          image: "{{ .Values.tasks.image.repository }}:{{ .Values.tasks.image.tag }}"
+          imagePullPolicy: {{ .Values.tasks.image.pullPolicy }}
+          command: ["sh", "-c", "/docker-entrypoint.sh events-tasks"]
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -42,11 +36,9 @@ spec:
               type: RuntimeDefault
           env:
           {{- include "yeti.envs" . | nindent 12 }}
-          ports:
-            - containerPort: 8000
           resources:
-            {{- toYaml .Values.api.resources | nindent 12 }}
-      {{- with .Values.api.nodeSelector }}
+            {{- toYaml .Values.events.resources | nindent 12 }}
+      {{- with .Values.events.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/osdfir-infrastructure/charts/yeti/templates/secret.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/secret.yaml
@@ -11,10 +11,10 @@ data:
   {{ $secretName := printf "%s-yeti-secret" (.Release.Name) }}
   yeti-user: {{ index (lookup "v1" "Secret" .Release.Namespace $secretName).data "yeti-user" }}
   yeti-arangodb: {{ index (lookup "v1" "Secret" .Release.Namespace $secretName).data "yeti-arangodb" }}
-  yeti-api: {{ index (lookup "v1" "Secret" .Release.Namespace $secretName).data "yeti-api" }}
+  yeti-secret: {{ index (lookup "v1" "Secret" .Release.Namespace $secretName).data "yeti-secret" }}
   {{- else }}
   yeti-user: {{ randAlphaNum 32 | b64enc | quote }}
   yeti-arangodb: {{ randAlphaNum 16 | b64enc | quote }}
-  yeti-api: {{ randNumeric 64 | lower | b64enc | quote }}
+  yeti-secret: {{ randAlphaNum 32 | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/osdfir-infrastructure/charts/yeti/values.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/values.yaml
@@ -13,6 +13,11 @@ global:
     ## @param global.yeti.enabled Enables the Yeti deployment (only used in the main OSDFIR Infrastructure Helm chart)
     ##
     enabled: false
+    ## @param global.yeti.apiKeySecret Existing secret containing Yeti API Key.
+    ## Please ensure that the Secret has been created then re-deploy the Helm chart when integrating Yeti with Timesketch
+    ## (e.g. kubectl create secret generic yeti-api-secret --from-literal=yeti-api=${YETI_API_KEY})
+    ##
+    apiKeySecret: ""
   ingress:
     ## @param global.ingress.enabled Enable the global loadbalancer for external access (only used in the main OSDFIR Infrastructure Helm chart)
     ##
@@ -33,7 +38,7 @@ frontend:
     pullPolicy: IfNotPresent
     ## @param frontend.image.tag Overrides the image tag whose default is the chart appVersion
     ##
-    tag: 2.2.2
+    tag: 2.4.2
   ## Yeti frontend resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param frontend.resources.limits Resource limits for the frontend container
@@ -65,7 +70,7 @@ api:
     pullPolicy: IfNotPresent
     ## @param api.image.tag Overrides the image tag whose default is the chart appVersion
     ##
-    tag: 2.2.2
+    tag: 2.4.2
   ## Yeti api resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param api.resources.limits Resource limits for the API container
@@ -97,11 +102,85 @@ tasks:
     pullPolicy: IfNotPresent
     ## @param tasks.image.tag Overrides the image tag whose default is the chart appVersion
     ##
-    tag: 2.2.2
+    tag: 2.4.2
   ## Yeti tasks resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param tasks.resources.limits Resource limits for the tasks container
   ## @param tasks.resources.requests Requested resources for the tasks container
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 500m
+    ##    memory: 1Gi
+    limits: {}
+    ## Example:
+    ## requests:
+    ##    cpu: 500m
+    ##    memory: 1Gi
+    requests: {}
+  ## @param tasks.nodeSelector Node labels for Yeti tasks pods assignment
+  ##
+  nodeSelector: {}
+## @section Yeti Task events configuration
+##
+events:
+  ## Yeti tasks resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param tasks.resources.limits Resource limits for the tasks container
+  ## @param tasks.resources.requests Requested resources for the tasks container
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 500m
+    ##    memory: 1Gi
+    limits: {}
+    ## Example:
+    ## requests:
+    ##    cpu: 500m
+    ##    memory: 1Gi
+    requests: {}
+  ## @param tasks.nodeSelector Node labels for Yeti tasks pods assignment
+  ##
+  nodeSelector: {}
+## @section Yeti Tasks beat configuration
+##
+beats:
+  ## Yeti tasks resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param tasks.resources.limits Resource limits for the tasks container
+  ## @param tasks.resources.requests Requested resources for the tasks container
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 500m
+    ##    memory: 1Gi
+    limits: {}
+    ## Example:
+    ## requests:
+    ##    cpu: 500m
+    ##    memory: 1Gi
+    requests: {}
+  ## @param tasks.nodeSelector Node labels for Yeti tasks pods assignment
+  ##
+  nodeSelector: {}
+## @section Yeti Bloomcheck configuration
+##
+bloomcheck:
+  image:
+    ## @param bloomcheck.image.repository Yeti tasks image repository
+    ##
+    repository: yetiplatform/bloomcheck
+    ## @param tasks.image.pullPolicy Yeti image pull policy
+    ## ref https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+    ##
+    pullPolicy: IfNotPresent
+    ## @param bloomcheck.image.tag Overrides the image tag whose default is the chart appVersion
+    ##
+    tag: dev
+  ## Yeti bloomcheck resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param bloomcheck.resources.limits Resource limits for the tasks container
+  ## @param bloomcheck.resources.requests Requested resources for the tasks container
   resources:
     ## Example:
     ## limits:
@@ -124,6 +203,9 @@ config:
   ## Secret name must follow the naming convention of {{ .Release.Name }}-yeti-secret
   ##
   existingSecret: false
+  ## @param config.createUser Creates a default Yeti user that can be used to login to Yeti after deployment
+  ##
+  createUser: true
   ## Yeti OIDC configuration
   ##
   oidc:

--- a/charts/osdfir-infrastructure/values.yaml
+++ b/charts/osdfir-infrastructure/values.yaml
@@ -21,6 +21,11 @@ global:
     ## @param global.yeti.enabled Enables the Yeti deployment (only used in the main OSDFIR Infrastructure Helm chart)
     ##
     enabled: true
+    ## @param global.yeti.apiKeySecret Existing secret containing Yeti API Key.
+    ## Please ensure that the Secret has been created then re-deploy the Helm chart when integrating Yeti with Timesketch
+    ## (e.g. kubectl create secret generic yeti-api-secret --from-literal=yeti-api=${YETI_API_KEY})
+    ##
+    apiKeySecret: ""
   openrelik:
     ## @param global.openrelik.enabled Enables the OpenRelik deployment (only used in the main OSDFIR Infrastructure Helm chart)
     ##


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

<!-- Describe what the change does. -->

Updates Yeti to the latest containers and fix integration with Timesketch 

The way API keys are created has changed since the last update and they can no longer be created at startup, so this PR updates the container versions of Yeti while also updating the logic that integrates Timesketch with Yeti. This is done by introducing a new global variable `.Values.global.yeti.apiKeySecret` where the user will have to create after the deployment then re-upgrade the helm chart to apply the changes and allow for integration to work. This has only been tested when using local passwords and likely some changes are needed for Oauth (will address at a later time if needed)

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Newly added variables are documented in the values.yaml
- [x] Title of the pull request is descriptive
