### PR TITLE
charts/timesketch Fix opensearch service to match new Timesketch config

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: timesketch
   repository: file://charts/timesketch
-  version: 2.2.2
+  version: 2.3.0
 - name: yeti
   repository: file://charts/yeti
   version: 2.2.1
@@ -14,5 +14,5 @@ dependencies:
 - name: hashr
   repository: file://charts/hashr
   version: 2.0.0
-digest: sha256:6e162b580397c9f65944e488fdbba13f19611954ca1f542de320b5008b74c94c
-generated: "2025-08-14T12:25:15.8057-07:00"
+digest: sha256:efa7eecb36fb55db5e7d17a87bf591fbf95db52e81ed6fb4518c9b56bc0a6bcf
+generated: "2025-09-04T11:59:51.541996-07:00"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
 - condition: global.timesketch.enabled
   name: timesketch
   repository: file://charts/timesketch
-  version: 2.2.2
+  version: 2.3.0
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti

--- a/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 2.2.2
+version: 2.3.0
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/_helpers.tpl
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Postgresql connection url
 Opensearch host name
 */}}
 {{- define "timesketch.opensearch.host" -}}
-{{- printf "%s-opensearch-cluster" .Release.Name -}}
+{{- printf "[{ \"host\": \"%s-opensearch-cluster\", \"port\": 9200}]" .Release.Name -}}
 {{- end -}}
 
 {{/*

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/init-configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/init-configmap.yaml
@@ -55,7 +55,7 @@ data:
     sed -i 's#postgresql://<USERNAME>:<PASSWORD>@localhost/timesketch#{{ include "timesketch.postgresql.url" . }}#' timesketch.conf
 
     # Set up the Opensearch connection
-    sed -i 's#^OPENSEARCH_HOST =.*#OPENSEARCH_HOST = {{ (include "timesketch.opensearch.host" .) | quote }}#' timesketch.conf
+    sed -i 's#^OPENSEARCH_HOSTS =.*#OPENSEARCH_HOSTS = {{ (include "timesketch.opensearch.host" .) }}#' timesketch.conf
 
     # Set up secret
     sed -i 's#^SECRET_KEY =.*#SECRET_KEY = "'$TIMESKETCH_SECRET'"#' timesketch.conf


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

<!-- Describe what the change does. -->
Due to https://github.com/google/timesketch/pull/3483

`OPENSEARCH_HOST` transitioned to `OPENSEARCH_HOSTS` so init script that runs before the Timesketch pod runs failed to replace the opensearch host and was left with the defaults `OPENSEARCH_HOSTS = [{"host": "opensearch", "port": 9200}]`

The changes here fix the init script to change instead the new variable in the new dictionary format

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Newly added variables are documented in the values.yaml
- [X] Title of the pull request is descriptive
