### PR TITLE
charts/{yeti,openrelik,timesketch} dependency checks init containers

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: timesketch
   repository: file://charts/timesketch
-  version: 2.3.1
+  version: 2.4.0
 - name: yeti
   repository: file://charts/yeti
-  version: 2.2.1
+  version: 2.3.0
 - name: openrelik
   repository: file://charts/openrelik
-  version: 2.1.6
+  version: 2.2.0
 - name: grr
   repository: file://charts/grr
   version: 2.2.0
 - name: hashr
   repository: file://charts/hashr
   version: 2.0.0
-digest: sha256:ed8d15c36840b7747965746fdb708a48f39f2a8a2c1196a2d008fc2e43b94854
-generated: "2025-09-24T08:47:30.285222-07:00"
+digest: sha256:9923e037fcacb836af38569c7cad1c1afc1d006da06dba603e05d4f3441c561d
+generated: "2025-10-03T15:39:55.807398-07:00"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.5.2
+version: 2.6.0
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch
@@ -14,15 +14,15 @@ dependencies:
 - condition: global.timesketch.enabled
   name: timesketch
   repository: file://charts/timesketch
-  version: 2.3.1
+  version: 2.4.0
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti
-  version: 2.2.1
+  version: 2.3.0
 - condition: global.openrelik.enabled
   name: openrelik
   repository: file://charts/openrelik
-  version: 2.1.6
+  version: 2.2.0
 - condition: global.grr.enabled
   name: grr
   repository: file://charts/grr

--- a/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: openrelik
-version: 2.1.6
+version: 2.2.0
 description: A Helm chart for Openrelik Kubernetes deployments.
 keywords:
 - openrelik

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/_helpers.tpl
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/_helpers.tpl
@@ -5,7 +5,6 @@ Common labels
 {{ include "openrelik.selectorLabels" . }}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-date: "{{ now | htmlDate }}"
 {{- end }}
 
 {{/*

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/_initContainerApi.tpl
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/_initContainerApi.tpl
@@ -1,0 +1,35 @@
+{{/*
+Init Container for when the OpenRelik API starts. Required for setting up
+OIDC when enabled due to the changes having to be in settings.toml
+*/}}
+{{- define "openrelik.initContainerApi" -}}
+- name: init-openrelik
+  image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+  command: ['sh', '-c', '/init/init-openrelik.sh']
+  {{- if and .Values.config.oidc.enabled .Values.config.oidc.existingSecret }} 
+  env:
+    - name: OIDC_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.config.oidc.existingSecret | quote }}
+          key: "client-id"
+    - name: OIDC_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.config.oidc.existingSecret | quote }}
+          key: "client-secret"
+  {{- end }}
+  volumeMounts:
+    - mountPath: /tmp/openrelik/settings.toml
+      subPath: settings.toml
+      name: settings-config
+    - mountPath: /init/
+      name: init-oidc
+    - mountPath: /etc/openrelik
+      name: openrelik-configs-dir
+    {{- if .Values.config.oidc.authenticatedEmailsFile.enabled }}
+    - name: authenticated-emails
+      mountPath: /init/authenticated-emails
+      readOnly: true
+    {{- end }}
+{{- end }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/api-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/api-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       hostIPC: false
       automountServiceAccountToken: false
       initContainers:
+      {{- include "openrelik.initContainerApi" . | nindent 8 }}
       {{- include "openrelik.initContainer" . | nindent 8 }}
       containers:
         - name: api

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/mediator-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/mediator-deployment.yaml
@@ -21,6 +21,8 @@ spec:
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
+      initContainers:
+      {{- include "openrelik.initContainer" . | nindent 8 }}
       containers:
         - name: mediator
           image: "{{ .Values.mediator.image.repository }}:{{ .Values.mediator.image.tag }}"

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/metrics-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/metrics-deployment.yaml
@@ -24,8 +24,10 @@ spec:
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
+      initContainers:
+      {{- include "openrelik.initContainer" . | nindent 8 }}
       containers:
-        - name: mediator
+        - name: metrics
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           command: ["/bin/sh", "-c", "python exporter.py"]

--- a/charts/osdfir-infrastructure/charts/openrelik/values.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/values.yaml
@@ -329,6 +329,13 @@ config:
     ## for loading the nbd module
     ##
     image: "us-central1-docker.pkg.dev/osdfir-registry/openrelik/openrelik-nbd-init:0.1.0"
+  ## OpenRelik dependency checker init container.
+  ## Waits for required services like Redis and Postgres to be ready before the main container starts.
+  ##
+  initDependencyCheck:
+    ## @param config.initDependencyCheck.image Container image with nslookup, necessary for the checks
+    ##
+    image: "registry.k8s.io/e2e-test-images/agnhost:2.40"
   ## @param config.createUser Create a default `openrelik` user.
   ##
   createUser: true

--- a/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 2.3.1
+version: 2.4.0
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/_helpers.tpl
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/_helpers.tpl
@@ -5,7 +5,6 @@ Common labels
 {{ include "timesketch.selectorLabels" . }}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-date: "{{ now | htmlDate }}"
 {{- end }}
 
 {{/*

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/_initContainer.tpl
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/_initContainer.tpl
@@ -69,4 +69,20 @@ Worker pod upon startup.
       mountPath: /init/authenticated-emails
       readOnly: true
     {{- end }}
+- name: wait-for-deps
+  image: "{{ .Values.config.initDependencyCheck.image }}"
+  command: ['sh', '-c']
+  args: 
+    - |
+      # Wait for Postgres
+      until nslookup {{ .Release.Name }}-timesketch-postgres.{{ .Release.Namespace }}.svc.cluster.local; do echo waiting for Postgres; sleep 2; done
+      echo "Postgres service is discoverable."
+
+      # Wait for Redis
+      until nslookup {{ .Release.Name }}-timesketch-redis.{{ .Release.Namespace }}.svc.cluster.local; do echo waiting for Redis; sleep 2; done
+      echo "Redis service is discoverable."
+
+      # Wait for Opensearch
+      until nslookup {{ .Release.Name }}-opensearch-cluster.{{ .Release.Namespace }}.svc.cluster.local; do echo waiting for Opensearch; sleep 2; done
+      echo "Opensearch service is discoverable."
 {{- end }}

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment.yaml
@@ -33,7 +33,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh", "-c", "gunicorn --bind 0.0.0.0:5000 --capture-output --timeout 600 --workers 4 timesketch.wsgi:application"]
-          {{- if .Values.config.createUser }}
+          {{- if and (not .Release.IsUpgrade) .Values.config.createUser }}
           lifecycle:
             postStart:
               exec:

--- a/charts/osdfir-infrastructure/charts/timesketch/values.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/values.yaml
@@ -48,6 +48,13 @@ config:
   ## Secret name must follow the naming convention of {{ .Release.Name }}-timesketch-secret
   ##
   existingSecret: false
+  ## Timesketch dependency checker init container.
+  ## Waits for required services including Redis, Opensearch, and Postgres to be ready before the main container starts.
+  ##
+  initDependencyCheck:
+    ## @param config.initDependencyCheck.image Container image with nslookup, necessary for the checks
+    ##
+    image: "registry.k8s.io/e2e-test-images/agnhost:2.40"
   ## @param config.createUser Creates a default Timesketch user that can be used to login to Timesketch after deployment
   ##
   createUser: true
@@ -158,7 +165,7 @@ persistence:
   existingPVC: ""
   ## @param persistence.size Timesketch persistent volume size
   ##
-  size: 2Gi
+  size: 100Gi
   ## @param persistence.storageClass PVC Storage Class for Timesketch volume
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined or set to null, no storageClassName spec is

--- a/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: yeti
-version: 2.2.1
+version: 2.3.0
 description: A Helm chart for Yeti Kubernetes deployments.
 keywords:
 - yeti

--- a/charts/osdfir-infrastructure/charts/yeti/templates/_helpers.tpl
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/_helpers.tpl
@@ -5,7 +5,6 @@ Common labels
 {{ include "yeti.selectorLabels" . }}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }} 
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-date: "{{ now | htmlDate }}"
 {{- end }}
 
 {{/*

--- a/charts/osdfir-infrastructure/charts/yeti/templates/_initContainer.tpl
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/_initContainer.tpl
@@ -1,0 +1,18 @@
+{{/*
+Init Container for checking for the Redis and ArangoDB service prior to starting
+the Yeti Pods.
+*/}}
+{{- define "yeti.initContainer" -}}
+- name: wait-for-deps
+  image: "{{ .Values.config.initDependencyCheck.image }}"
+  command: ['sh', '-c']
+  args: 
+    - |
+      # Wait for Redis
+      until nslookup {{ .Release.Name }}-yeti-redis.{{ .Release.Namespace }}.svc.cluster.local; do echo waiting for Redis; sleep 2; done
+      echo "Redis service is discoverable."
+
+      # Wait for ArangoDB
+      until nslookup {{ .Release.Name }}-yeti-arangodb.{{ .Release.Namespace }}.svc.cluster.local; do echo waiting for ArangoDB; sleep 2; done
+      echo "ArangoDB service is discoverable."
+{{- end }}

--- a/charts/osdfir-infrastructure/charts/yeti/templates/api-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/api-deployment.yaml
@@ -21,6 +21,8 @@ spec:
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
+      initContainers:
+      {{- include "yeti.initContainer" . | nindent 8 }}
       containers:
         - name: api
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
@@ -30,7 +32,7 @@ spec:
           lifecycle:
             postStart:
               exec:
-                command: ["sh", "-c", "uv run python yetictl/cli.py create-user yeti $YETI_USER_PASSWORD --admin"]
+                command: ["sh", "-c", "if ! uv run python yetictl/cli.py list-users | grep -q 'Username: yeti'; then uv run python yetictl/cli.py create-user yeti $YETI_USER_PASSWORD --admin; fi"]
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/osdfir-infrastructure/charts/yeti/templates/beats-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/beats-deployment.yaml
@@ -21,6 +21,8 @@ spec:
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
+      initContainers:
+      {{- include "yeti.initContainer" . | nindent 8 }}
       containers:
         - name: beats
           image: "{{ .Values.tasks.image.repository }}:{{ .Values.tasks.image.tag }}"

--- a/charts/osdfir-infrastructure/charts/yeti/templates/events-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/events-deployment.yaml
@@ -21,6 +21,8 @@ spec:
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
+      initContainers:
+      {{- include "yeti.initContainer" . | nindent 8 }}
       containers:
         - name: events
           image: "{{ .Values.tasks.image.repository }}:{{ .Values.tasks.image.tag }}"

--- a/charts/osdfir-infrastructure/charts/yeti/templates/tasks-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/tasks-deployment.yaml
@@ -21,6 +21,8 @@ spec:
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
+      initContainers:
+      {{- include "yeti.initContainer" . | nindent 8 }}
       containers:
         - name: tasks
           image: "{{ .Values.tasks.image.repository }}:{{ .Values.tasks.image.tag }}"

--- a/charts/osdfir-infrastructure/charts/yeti/values.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/values.yaml
@@ -203,6 +203,13 @@ config:
   ## Secret name must follow the naming convention of {{ .Release.Name }}-yeti-secret
   ##
   existingSecret: false
+  ## Yeti dependency checker init container.
+  ## Waits for required services including Redis and ArangoDB to be ready before the main container starts.
+  ##
+  initDependencyCheck:
+    ## @param config.initDependencyCheck.image Container image with nslookup, necessary for the checks
+    ##
+    image: "registry.k8s.io/e2e-test-images/agnhost:2.40"
   ## @param config.createUser Creates a default Yeti user that can be used to login to Yeti after deployment
   ##
   createUser: true


### PR DESCRIPTION
Add dependency check init containers to Yeti,OpenRelik, Timesketch to make startup more reliable when backend services are not yet ready. While these Pods do resolve after a minute or so, it does not make for the best UX seeing multiple containers initially failing.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Newly added variables are documented in the values.yaml
- [X] Title of the pull request is descriptive
