### PR TITLE
[Timesketch] Implement direct static file serving and tune Nginx proxy buffers

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -14,5 +14,5 @@ dependencies:
 - name: hashr
   repository: file://charts/hashr
   version: 2.0.1
-digest: sha256:d5a33c46ff1a1302773f88e477aa08019b14a9d3366070032f21f2844a74ffb4
-generated: "2026-02-05T15:59:04.340371-08:00"
+digest: sha256:fb89cb0fa14f1fb36a75b40eeeceafe8987036e6bfb0ab598af6921920a2d97a
+generated: "2026-02-10T09:47:11.377742907Z"

--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: timesketch
   repository: file://charts/timesketch
-  version: 2.4.5
+  version: 2.4.6
 - name: yeti
   repository: file://charts/yeti
   version: 2.2.5

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.7.7
+version: 2.7.8
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch
@@ -14,7 +14,7 @@ dependencies:
 - condition: global.timesketch.enabled
   name: timesketch
   repository: file://charts/timesketch
-  version: 2.4.5
+  version: 2.4.6
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti

--- a/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 2.4.5
+version: 2.4.6
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/nginx/nginx-configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/nginx/nginx-configmap.yaml
@@ -11,10 +11,22 @@ data:
         listen 8080;
         listen [::]:8080;
         client_max_body_size 0m;
+
+        # Serve static frontend assets directly from the filesystem.
+        # This prevents large JS/CSS bundles from being proxied through the
+        # application server, which avoids "upstream response is buffered
+        # to a temporary file" warnings and improves performance.
+        location /dist/ {
+            alias /usr/share/nginx/html/static/;
+            add_header Cache-Control "public, max-age=31536000";
+        }
+
         location / {
+            # Increased buffer sizes to handle larger metadata/responses in memory
+            # and avoid disk I/O for upstream responses.
             proxy_buffer_size 128k;
-            proxy_buffers 4 256k;
-            proxy_busy_buffers_size 256k;
+            proxy_buffers 16 1024k;
+            proxy_busy_buffers_size 2048k;
             proxy_pass http://{{ .Release.Name }}-timesketch:5000/;
             proxy_read_timeout {{ .Values.config.nginxReadTimeout }}s;
             proxy_set_header Host $host;
@@ -34,8 +46,8 @@ data:
         }
         location /v3 {
             proxy_buffer_size 128k;
-            proxy_buffers 4 256k;
-            proxy_busy_buffers_size 256k;
+            proxy_buffers 16 1024k;
+            proxy_busy_buffers_size 2048k;
             proxy_pass http://{{ .Release.Name }}-timesketch-v3:5000/;
             proxy_read_timeout {{ .Values.config.nginxReadTimeout }}s;
             proxy_set_header Host $host;

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/nginx/nginx-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/nginx/nginx-deployment.yaml
@@ -24,6 +24,32 @@ spec:
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
+      initContainers:
+        # The init-static container extracts compiled frontend assets from the 
+        # Timesketch image and places them into a shared volume so Nginx can 
+        # serve them directly without proxying to the web container.
+        - name: init-static
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: false
+            runAsGroup: 101
+            runAsNonRoot: true
+            runAsUser: 101
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          # Dynamically find the Timesketch package path and copy the 'dist' 
+          # folder contents to the shared volume.
+          command: ["/bin/sh", "-c", "export TS_PATH=$(python3 -c 'import timesketch; print(timesketch.__path__[0])'); if [ -d \"$TS_PATH/frontend/dist\" ]; then cp -rv $TS_PATH/frontend/dist/* /static/; elif [ -d \"$TS_PATH/frontend-ng/dist\" ]; then cp -rv $TS_PATH/frontend-ng/dist/* /static/; fi"]
+          volumeMounts:
+            - name: static-files
+              mountPath: /static
       containers:
         - name: nginx
           image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
@@ -46,6 +72,10 @@ spec:
               subPath: default.conf
               name: nginx-config
               readOnly: true
+            # Mount the shared static files from the initContainer
+            - mountPath: /usr/share/nginx/html/static
+              name: static-files
+              readOnly: true
             - mountPath: /var/cache/nginx
               name: tmp
             - mountPath: /var/run/
@@ -60,6 +90,9 @@ spec:
         - name: nginx-config
           configMap:
             name: {{ .Release.Name }}-timesketch-nginx-configmap
+        # Shared volume to transfer static assets from Timesketch image to Nginx
+        - name: static-files
+          emptyDir: {}
       {{- with .Values.nginx.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
This change optimizes how Timesketch frontend assets are served to resolve Nginx warnings regarding
 upstream responses being buffered to disk. By offloading static file delivery from the Python
 application server (Gunicorn) to Nginx, we reduce latency and CPU overhead on the backend.

Note: This PR received lots of help by Gemini