### PR TITLE
charts/timesketch Allow environment variables to be custom configured for pods and allow for creation of service account

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: timesketch
   repository: file://charts/timesketch
-  version: 2.5.1
+  version: 2.5.2
 - name: yeti
   repository: file://charts/yeti
   version: 2.2.8
@@ -14,5 +14,5 @@ dependencies:
 - name: hashr
   repository: file://charts/hashr
   version: 2.0.1
-digest: sha256:a7117e1f3f40a5f4fb967f1b96c31927429aba1cbc18872fbb321907ce778b0c
-generated: "2026-04-30T16:01:42.725794-07:00"
+digest: sha256:c02d94764b51c9e861a771287a3a694d6cb58ff65c4a8438c6245d733a6d47b4
+generated: "2026-05-05T12:05:09.682193-07:00"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.8.7
+version: 2.8.8
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch
@@ -14,7 +14,7 @@ dependencies:
 - condition: global.timesketch.enabled
   name: timesketch
   repository: file://charts/timesketch
-  version: 2.5.1
+  version: 2.5.2
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti

--- a/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 2.5.1
+version: 2.5.2
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/gcp/serviceaccount.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/gcp/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.config.enableServiceAccount }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: timesketch
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "timesketch.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment-v3.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment-v3.yaml
@@ -46,9 +46,9 @@ spec:
             {{- end }}
             - name: ENABLE_STRUCTURED_LOGGING
               value: "true"
-          {{- if .Values.frontend.env }}
-            {{- toYaml .Values.frontend.env | nindent 12 }} 
-          {{- end }}
+            {{- if .Values.frontend.env }}
+              {{- toYaml .Values.frontend.env | nindent 12 }} 
+            {{- end }}
           volumeMounts:
             - mountPath: /mnt/timesketchvolume
               name: timesketchvolume

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment-v3.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment-v3.yaml
@@ -26,6 +26,9 @@ spec:
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
+      {{- if .Values.config.enableServiceAccount }}
+      serviceAccountName: timesketch
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.frontend.terminationGracePeriodSeconds }}
       initContainers:
       {{- include "timesketch.initContainer" . | nindent 8 }}
@@ -43,6 +46,9 @@ spec:
             {{- end }}
             - name: ENABLE_STRUCTURED_LOGGING
               value: "true"
+          {{- if .Values.frontend.env }}
+            {{- toYaml .Values.frontend.env | nindent 12 }} 
+          {{- end }}
           volumeMounts:
             - mountPath: /mnt/timesketchvolume
               name: timesketchvolume

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment.yaml
@@ -26,6 +26,9 @@ spec:
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
+      {{- if .Values.config.enableServiceAccount }}
+      serviceAccountName: timesketch
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.frontend.terminationGracePeriodSeconds }}
       initContainers:
       {{- include "timesketch.initContainer" . | nindent 8 }}
@@ -54,6 +57,9 @@ spec:
             {{- end }}
             - name: ENABLE_STRUCTURED_LOGGING
               value: "true"
+          {{- if .Values.frontend.env }}
+            {{- toYaml .Values.frontend.env | nindent 12 }} 
+          {{- end }}
           volumeMounts:
             - mountPath: /mnt/timesketchvolume
               name: timesketchvolume

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment.yaml
@@ -57,9 +57,9 @@ spec:
             {{- end }}
             - name: ENABLE_STRUCTURED_LOGGING
               value: "true"
-          {{- if .Values.frontend.env }}
-            {{- toYaml .Values.frontend.env | nindent 12 }} 
-          {{- end }}
+            {{- if .Values.frontend.env }}
+              {{- toYaml .Values.frontend.env | nindent 12 }} 
+            {{- end }}
           volumeMounts:
             - mountPath: /mnt/timesketchvolume
               name: timesketchvolume

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/worker-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/worker-deployment.yaml
@@ -41,9 +41,9 @@ spec:
           env:
             - name: ENABLE_STRUCTURED_LOGGING
               value: "true"
-          {{- if .Values.worker.env }}
-            {{- toYaml .Values.worker.env | nindent 12 }} 
-          {{- end }} 
+            {{- if .Values.worker.env }}
+              {{- toYaml .Values.worker.env | nindent 12 }} 
+            {{- end }} 
           {{- if .Values.securityContext.enabled }}
           securityContext:
             capabilities:

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/worker-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/worker-deployment.yaml
@@ -27,6 +27,9 @@ spec:
       hostNetwork: false
       hostIPC: false
       automountServiceAccountToken: false
+      {{- if .Values.config.enableServiceAccount }}
+      serviceAccountName: timesketch
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
       initContainers:
       {{- include "timesketch.initContainer" . | nindent 8 }}
@@ -37,7 +40,10 @@ spec:
           command: ["sh", "-c", "exec celery -A timesketch.lib.tasks worker --loglevel={{ .Values.config.logLevel }}"]
           env:
             - name: ENABLE_STRUCTURED_LOGGING
-              value: "true" 
+              value: "true"
+          {{- if .Values.worker.env }}
+            {{- toYaml .Values.worker.env | nindent 12 }} 
+          {{- end }} 
           {{- if .Values.securityContext.enabled }}
           securityContext:
             capabilities:

--- a/charts/osdfir-infrastructure/charts/timesketch/values.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/values.yaml
@@ -83,6 +83,10 @@ config:
   ## @param config.nginxTimeout Number of seconds before Nginx times out on a read operation
   ##
   nginxReadTimeout: 600
+  ## @param config.enableServiceAccount Add the K8s service account `timesketch` to all Timesketch deployment manifests
+  ## This is useful when associationg additional cloud provider permissions with Timesketch pods (e.g. GCP trace explorer).
+  ##
+  enableServiceAccount: false
   ## Timesketch GCP optional features to enable
   ##
   gcp:
@@ -135,6 +139,14 @@ config:
 ## @section Timesketch Frontend Configuration
 ##
 frontend:
+  ## @param frontend.env Additional environment variables to pass to the Timesketch pod
+  ## To set environment variables, remove {} and replace with provided environment variables
+  ## Example
+  ## env:
+  ##   - name: example-name
+  ##     value: example-value
+  ##
+  env: []
   ## @param frontend.terminationGracePeriodSeconds The number of seconds to wait before K8s forcefully terminates the Pod
   ##
   terminationGracePeriodSeconds: 600
@@ -164,6 +176,10 @@ worker:
   ## @param worker.terminationGracePeriodSeconds The number of seconds to wait to finish current tasks before K8s forcefully terminates the Pod
   ##
   terminationGracePeriodSeconds: 600
+  ## @param worker.env Additional environment variables to pass to the Timesketch pod
+  ## To set environment variables, remove {} and replace with provided environment variables
+  ##
+  env: []
   ## Timesketch Worker resource requests and limits
   ## @param worker.resources.limits The resources limits for the worker container
   ## @param worker.resources.requests.cpu The requested cpu for the worker container


### PR DESCRIPTION
…ds and allow for the configuration of a k8s service account (e.g. for when needing to assign specific permissions such as gcp trace explorer)

<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

<!-- Describe what the change does. -->

This change:
  * Adds `.Values.frontend.env` and `.Values.worker.env` to allow for custom environment variables to be passed to Timesketch pods.
  * Adds `.Values.config.enableServiceAccount` which allows for the creation of a Timesketch service account, which then gets referenced in Timesketch pods. This is useful for when having to associate specific permissions (e.g. GCP trace explorer with workload identity)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Newly added variables are documented in the values.yaml
- [X] Title of the pull request is descriptive
