### PR TITLE
charts/yeti Fix race condition with duplicate feeds

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 2.5.2
 - name: yeti
   repository: file://charts/yeti
-  version: 2.2.8
+  version: 2.2.9
 - name: openrelik
   repository: file://charts/openrelik
   version: 2.3.2
@@ -14,5 +14,5 @@ dependencies:
 - name: hashr
   repository: file://charts/hashr
   version: 2.0.1
-digest: sha256:c02d94764b51c9e861a771287a3a694d6cb58ff65c4a8438c6245d733a6d47b4
-generated: "2026-05-05T12:05:09.682193-07:00"
+digest: sha256:7381ebf95a813fa8258b8f696b846cb2125cc2adaec548134044994291071a1b
+generated: "2026-05-26T10:45:53.904839-07:00"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.8.8
+version: 2.8.9
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch
@@ -18,7 +18,7 @@ dependencies:
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti
-  version: 2.2.8
+  version: 2.2.9
 - condition: global.openrelik.enabled
   name: openrelik
   repository: file://charts/openrelik

--- a/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: yeti
-version: 2.2.8
+version: 2.2.9
 description: A Helm chart for Yeti Kubernetes deployments.
 keywords:
 - yeti

--- a/charts/osdfir-infrastructure/charts/yeti/templates/_initContainer.tpl
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/_initContainer.tpl
@@ -16,3 +16,22 @@ the Yeti Pods.
       until nslookup {{ .Release.Name }}-yeti-arangodb; do echo waiting for ArangoDB; sleep 30; done
       echo "ArangoDB service is discoverable."
 {{- end }}
+
+{{/*
+Init Container for checking if the Yeti API service is up and running.
+This is used by background workers to avoid race conditions during database initialization.
+*/}}
+{{- define "yeti.waitForApi" -}}
+- name: wait-for-api
+  image: "{{ .Values.config.initDependencyCheck.image }}"
+  command: ['sh', '-c']
+  args: 
+    - |
+      # Wait for Yeti API to be listening
+      until wget -q -O- http://{{ .Release.Name }}-yeti-api:8000/openapi.json > /dev/null 2>&1; do
+        echo "Waiting for Yeti API to be healthy and initialized..."
+        sleep 5
+      done
+      sleep 30
+      echo "Yeti API is fully ready."
+{{- end }}

--- a/charts/osdfir-infrastructure/charts/yeti/templates/api-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/api-deployment.yaml
@@ -27,13 +27,16 @@ spec:
         - name: api
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.config.imagePullPolicy }}
-          command: ["sh", "-c", "/docker-entrypoint.sh webserver"]
-          {{- if and (not .Release.IsUpgrade) .Values.config.createUser }}
-          lifecycle:
-            postStart:
-              exec:
-                command: ["sh", "-c", "if ! uv run python yetictl/cli.py list-users | grep -q 'Username: yeti'; then uv run python yetictl/cli.py create-user yeti $YETI_USER_PASSWORD --admin; fi"]
-          {{- end }}
+          command:
+            - "sh"
+            - "-c"
+            - |
+              {{- if and (not .Release.IsUpgrade) .Values.config.createUser }}
+              if ! uv run python yetictl/cli.py list-users | grep -q 'Username: yeti'; then
+                uv run python yetictl/cli.py create-user yeti $YETI_USER_PASSWORD --admin
+              fi
+              {{- end }}
+              exec /docker-entrypoint.sh webserver
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/osdfir-infrastructure/charts/yeti/templates/beats-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/beats-deployment.yaml
@@ -23,6 +23,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         {{- include "yeti.initContainer" . | nindent 8 }}
+        {{- include "yeti.waitForApi" . | nindent 8 }}
       containers:
         - name: beats
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"

--- a/charts/osdfir-infrastructure/charts/yeti/templates/events-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/events-deployment.yaml
@@ -23,6 +23,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         {{- include "yeti.initContainer" . | nindent 8 }}
+        {{- include "yeti.waitForApi" . | nindent 8 }}
       containers:
         - name: events
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"

--- a/charts/osdfir-infrastructure/charts/yeti/templates/tasks-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/tasks-deployment.yaml
@@ -23,6 +23,7 @@ spec:
       automountServiceAccountToken: false
       initContainers:
         {{- include "yeti.initContainer" . | nindent 8 }}
+        {{- include "yeti.waitForApi" . | nindent 8 }}
       containers:
         - name: tasks
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

<!-- Describe what the change does. -->

Upon initial startup/creation of Yeti. There is a race condition that could occur with Yeti Feeds appearing twice in the UI. This is due to a lack of a unique key in Yeti, thus allowing for duplicate feeds to be created. This fix prevents this, by making sure the sub components Yeti uses (task, events, beats) do not start up at the same time as Yeti and that the default yeti user (which reloads code and also causes feeds to be created) that gets created runs before yeti starts up

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Newly added variables are documented in the values.yaml
- [X] Title of the pull request is descriptive
