### PR TITLE
openrelik: IAP support, single-host ingress mode, BackendConfig fix

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 2.2.9
 - name: openrelik
   repository: file://charts/openrelik
-  version: 2.3.2
+  version: 2.4.0
 - name: grr
   repository: file://charts/grr
   version: 2.3.1
 - name: hashr
   repository: file://charts/hashr
   version: 2.0.1
-digest: sha256:7381ebf95a813fa8258b8f696b846cb2125cc2adaec548134044994291071a1b
-generated: "2026-05-26T10:45:53.904839-07:00"
+digest: sha256:d344c912a024d28a508809dedb9ce95427acc14fd92f1bc9ccc51a09feba656c
+generated: "2026-06-02T05:06:20.334681458Z"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.8.9
+version: 2.9.0
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch
@@ -22,7 +22,7 @@ dependencies:
 - condition: global.openrelik.enabled
   name: openrelik
   repository: file://charts/openrelik
-  version: 2.3.2
+  version: 2.4.0
 - condition: global.grr.enabled
   name: grr
   repository: file://charts/grr

--- a/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: openrelik
-version: 2.3.2
+version: 2.4.0
 description: A Helm chart for Openrelik Kubernetes deployments.
 keywords:
 - openrelik

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/configmap.yaml
@@ -82,6 +82,22 @@ data:
     public_access = false
     {{ end -}}
 
+    {{- if .Values.config.iap.enabled }}
+    [auth.iap]
+    # Google Cloud IAP authentication: validates the signed
+    # X-Goog-IAP-JWT-Assertion header added by the proxy.
+    audience = "{{ .Values.config.iap.audience }}"
+    {{- if .Values.config.iap.allowlist }}
+    allowlist = {{ .Values.config.iap.allowlist | toJson }}
+    public_access = false
+    {{- else }}
+    allowlist = []
+    # Only identities that IAP has authenticated and authorized carry a valid
+    # assertion, so access control can be fully delegated to IAP policy.
+    public_access = {{ .Values.config.iap.publicAccess }}
+    {{- end }}
+    {{- end }}
+
     [ui]
     # data_types that will be rendered using unescaped HTML in a sandboxed iframe in the
     # frontend UI.

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/frontend-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/frontend-deployment.yaml
@@ -38,7 +38,9 @@ spec:
             - name: OPENRELIK_API_VERSION
               value: v1
             - name: OPENRELIK_AUTH_METHODS
-              {{- if .Values.config.oidc.enabled }}
+              {{- if .Values.config.iap.enabled }}
+              value: iap
+              {{- else if .Values.config.oidc.enabled }}
               value: google
               {{- else }}
               value: local

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/api-backendconfig.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/api-backendconfig.yaml
@@ -6,6 +6,12 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   timeoutSec: 300
+  {{- if and .Values.config.iap.enabled .Values.config.iap.existingSecret }}
+  iap:
+    enabled: true
+    oauthclientCredentials:
+      secretName: {{ .Values.config.iap.existingSecret }}
+  {{- end }}
   healthCheck:
     checkIntervalSec: 60
     timeoutSec: 5

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/frontend-backendconfig.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/frontend-backendconfig.yaml
@@ -6,6 +6,12 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   timeoutSec: 300
+  {{- if and .Values.config.iap.enabled .Values.config.iap.existingSecret }}
+  iap:
+    enabled: true
+    oauthclientCredentials:
+      secretName: {{ .Values.config.iap.existingSecret }}
+  {{- end }}
   healthCheck:
     checkIntervalSec: 300
     timeoutSec: 5

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/nginx/nginx-service.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/nginx/nginx-service.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- if (eq .Values.global.ingress.className "gce") }}
   annotations:
     cloud.google.com/neg: '{"ingress": true}'
-    cloud.google.com/backend-config: '{"ports": {"8710":"{{ .Release.Name }}-openrelik-api-backend-config"}, "8711":"{{ .Release.Name }}-openrelik-backend-config"}'
+    cloud.google.com/backend-config: '{"ports": {"8710":"{{ .Release.Name }}-openrelik-api-backend-config"}, "8711":"{{ .Release.Name }}-openrelik-frontend-backend-config"}'
   {{- end }}
 spec:
   type: ClusterIP

--- a/charts/osdfir-infrastructure/charts/openrelik/values.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/values.yaml
@@ -457,6 +457,28 @@ config:
       ## content: |-
       ##   name1@domain
       ##   name2@domain
+  ## OpenRelik Google Cloud IAP (Identity-Aware Proxy) authentication.
+  ## Validates the signed X-Goog-IAP-JWT-Assertion header that IAP adds to
+  ## proxied requests. Requires an OpenRelik server image with the "iap"
+  ## auth method and a GCE Ingress with IAP enabled on the backend.
+  ##
+  iap:
+    ## @param config.iap.enabled Enables OpenRelik IAP authentication
+    ##
+    enabled: false
+    ## @param config.iap.existingSecret Existing secret with the IAP OAuth client_id and client_secret (referenced by the BackendConfig to enable IAP on the load balancer)
+    ## e.g. kubectl create secret generic iap-oauth --from-literal=client_id=... --from-literal=client_secret=...
+    existingSecret: ""
+    ## @param config.iap.audience Expected JWT audience of the IAP assertion, e.g. /projects/PROJECT_NUMBER/global/backendServices/SERVICE_ID
+    ##
+    audience: ""
+    ## @param config.iap.allowlist Allow only these users (email addresses). When set, public access is disabled.
+    ##
+    allowlist: []
+    ## @param config.iap.publicAccess Admit any identity asserted by IAP (access control fully delegated to IAP policy)
+    ##
+    publicAccess: true
+
 ## Persistence Storage Parameters
 ##
 persistence:

--- a/charts/osdfir-infrastructure/templates/gcp/managedcertificate.yaml
+++ b/charts/osdfir-infrastructure/templates/gcp/managedcertificate.yaml
@@ -15,7 +15,7 @@ spec:
     {{- if and .Values.global.openrelik.enabled .Values.global.ingress.openRelikFrontendHost }}
     - {{ .Values.global.ingress.openRelikFrontendHost }}
     {{- end }}
-    {{- if and .Values.global.openrelik.enabled .Values.global.ingress.openRelikAPIHost }}
+    {{- if and .Values.global.openrelik.enabled .Values.global.ingress.openRelikAPIHost (ne .Values.global.ingress.openRelikAPIHost .Values.global.ingress.openRelikFrontendHost) }}
     - {{ .Values.global.ingress.openRelikAPIHost }}
     {{- end }}
 {{- end }}

--- a/charts/osdfir-infrastructure/templates/ingress.yaml
+++ b/charts/osdfir-infrastructure/templates/ingress.yaml
@@ -80,7 +80,7 @@ spec:
     - host: {{ .Values.global.ingress.openRelikFrontendHost }}
       http:
         paths:
-          {{- range $apiPath := list "/api" "/auth" "/login" "/openapi.json" "/docs" }}
+          {{- range $apiPath := list "/api" "/auth" "/login/" "/openapi.json" "/docs" }}
           - path: {{ $apiPath }}
             pathType: Prefix
             backend:

--- a/charts/osdfir-infrastructure/templates/ingress.yaml
+++ b/charts/osdfir-infrastructure/templates/ingress.yaml
@@ -72,6 +72,31 @@ spec:
                 port:
                   number: 9000
     {{- end }}
+    {{- if and .Values.global.ingress.openRelikFrontendHost (eq .Values.global.ingress.openRelikFrontendHost (.Values.global.ingress.openRelikAPIHost | default "")) }}
+    {{- /* Single-host mode: same origin for UI and API avoids cross-origin
+           cookie and CORS handling (relevant for auth proxies such as IAP,
+           which keep per-host sessions). API routes are matched by prefix;
+           everything else serves the UI. */}}
+    - host: {{ .Values.global.ingress.openRelikFrontendHost }}
+      http:
+        paths:
+          {{- range $apiPath := list "/api" "/auth" "/login" "/openapi.json" "/docs" }}
+          - path: {{ $apiPath }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $.Release.Name }}-openrelik-nginx
+                port:
+                  number: 8710
+          {{- end }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-openrelik-nginx
+                port:
+                  number: 8711
+    {{- else }}
     {{- if .Values.global.ingress.openRelikFrontendHost }}
     - host: {{.Values.global.ingress.openRelikFrontendHost }}
       http:
@@ -95,5 +120,6 @@ spec:
                 name: {{ .Release.Name }}-openrelik-nginx
                 port:
                   number: 8710
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/osdfir-infrastructure/templates/ingress.yaml
+++ b/charts/osdfir-infrastructure/templates/ingress.yaml
@@ -80,9 +80,12 @@ spec:
     - host: {{ .Values.global.ingress.openRelikFrontendHost }}
       http:
         paths:
-          {{- range $apiPath := list "/api" "/auth" "/login/" "/openapi.json" "/docs" }}
+          {{- /* GCE translates Prefix "/p/" into both "/p" and "/p/*"; use
+                 ImplementationSpecific so bare /login stays a frontend route
+                 while /login/<method> reaches the API. */}}
+          {{- range $apiPath := list "/api/*" "/auth/*" "/login/*" "/openapi.json" "/docs" "/docs/*" }}
           - path: {{ $apiPath }}
-            pathType: Prefix
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ $.Release.Name }}-openrelik-nginx


### PR DESCRIPTION
## Summary

Adds Google Cloud IAP support and a single-host ingress mode to the OpenRelik chart, plus a fix for a broken BackendConfig reference.

- **IAP support** (`config.iap.*`): when enabled, the rendered `settings.toml` gets an `[auth.iap]` section (for OpenRelik server builds with the `iap` auth method), the frontend advertises the `iap` login method, and both GCE BackendConfigs enable IAP from an existing OAuth-client Secret. This lets deployments delegate access control to IAP policy (e.g. Google Groups) with the app cryptographically validating the signed proxy assertions.
- **Single-host mode**: when `openRelikFrontendHost` and `openRelikAPIHost` are set to the same value, the ingress renders one host with API path routing (`/api/*`, `/auth/*`, `/login/*`, `/openapi.json`, `/docs`) and the UI as default. A single origin avoids cross-origin cookie and CORS handling, which matters behind per-host-session auth proxies such as IAP. Paths use `ImplementationSpecific` because GCE expands a `Prefix` rule for `/p/` into both `/p` and `/p/*`, which would capture the frontend's own `/login` route. The managed-certificate template skips the duplicate domain in this mode.
- **Bugfix**: the nginx Service annotation referenced `...-openrelik-backend-config` for port 8711, a BackendConfig this chart does not create (it creates `...-openrelik-frontend-backend-config`), so the frontend port silently received no BackendConfig at all.

## Testing

Deployed on GKE Autopilot with a GCE ingress, Google-managed certificates and real IAP: both ports verified IAP-gated (302 with `x-goog-iap-generated-response`), the frontend's `/login` route serves the UI while `/login/iap` reaches the API, and an end-to-end workflow (login through IAP, upload, worker execution) passes against the deployment. `helm template` output verified for both single-host and two-host configurations, with the other charts disabled and enabled.
