### PR TITLE
charts/* Add pod disruption budget and safe-to-evict:false for all Redis/Postgres/Arangodb pods

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: timesketch
   repository: file://charts/timesketch
-  version: 2.5.2
+  version: 2.5.3
 - name: yeti
   repository: file://charts/yeti
-  version: 2.2.9
+  version: 2.3.0
 - name: openrelik
   repository: file://charts/openrelik
-  version: 2.4.0
+  version: 2.4.1
 - name: grr
   repository: file://charts/grr
   version: 2.3.1
 - name: hashr
   repository: file://charts/hashr
   version: 2.0.1
-digest: sha256:d344c912a024d28a508809dedb9ce95427acc14fd92f1bc9ccc51a09feba656c
-generated: "2026-06-02T05:06:20.334681458Z"
+digest: sha256:6462892ff8dffe9847d8edf07d45551bd242327cd5c4dc9effeb1770d32c0a5b
+generated: "2026-06-10T10:23:46.583195-07:00"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.9.0
+version: 2.9.1
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -14,15 +14,15 @@ dependencies:
 - condition: global.timesketch.enabled
   name: timesketch
   repository: file://charts/timesketch
-  version: 2.5.2
+  version: 2.5.3
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti
-  version: 2.2.9
+  version: 2.3.0
 - condition: global.openrelik.enabled
   name: openrelik
   repository: file://charts/openrelik
-  version: 2.4.0
+  version: 2.4.1
 - condition: global.grr.enabled
   name: grr
   repository: file://charts/grr

--- a/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: openrelik
-version: 2.4.0
+version: 2.4.1
 description: A Helm chart for Openrelik Kubernetes deployments.
 keywords:
 - openrelik

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/postgres/postgres-pdb.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/postgres/postgres-pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: openrelik-postgres-pdb
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: postgres
+      app.kubernetes.io/name: openrelik

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/postgres/postgres-pdb.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/postgres/postgres-pdb.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: openrelik-postgres-pdb
+  name: {{ .Release.Name }}-openrelik-postgres-pdb
   namespace: {{ .Release.Namespace | quote }}
 spec:
   minAvailable: 1

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/postgres/postgres-statefulset.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/postgres/postgres-statefulset.yaml
@@ -14,6 +14,8 @@ spec:
       {{- include "openrelik.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app.kubernetes.io/component: postgres
         {{- include "openrelik.selectorLabels" . | nindent 8 }}

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/redis/redis-pdb.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/redis/redis-pdb.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: openrelik-redis-pdb
+  name: {{ .Release.Name }}-openrelik-redis-pdb
   namespace: {{ .Release.Namespace | quote }}
 spec:
   minAvailable: 1

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/redis/redis-pdb.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/redis/redis-pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: openrelik-redis-pdb
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: redis
+      app.kubernetes.io/name: openrelik

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/redis/redis-statefulset.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/redis/redis-statefulset.yaml
@@ -14,6 +14,8 @@ spec:
       {{- include "openrelik.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app.kubernetes.io/component: redis
         {{- include "openrelik.selectorLabels" . | nindent 8 }}

--- a/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 2.5.2
+version: 2.5.3
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/postgres/postgres-pdb.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/postgres/postgres-pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: timesketch-postgres-pdb
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: postgres
+      app.kubernetes.io/name: timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/postgres/postgres-pdb.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/postgres/postgres-pdb.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: timesketch-postgres-pdb
+  name: {{ .Release.Name }}-timesketch-postgres-pdb
   namespace: {{ .Release.Namespace | quote }}
 spec:
   minAvailable: 1

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/postgres/postgres-statefulset.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/postgres/postgres-statefulset.yaml
@@ -14,6 +14,8 @@ spec:
       {{- include "timesketch.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app.kubernetes.io/component: postgres
         {{- include "timesketch.selectorLabels" . | nindent 8 }}

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/redis/redis-pdb.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/redis/redis-pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: timesketch-redis-pdb
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: redis
+      app.kubernetes.io/name: timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/redis/redis-pdb.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/redis/redis-pdb.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: timesketch-redis-pdb
+  name: {{ .Release.Name }}-timesketch-redis-pdb
   namespace: {{ .Release.Namespace | quote }}
 spec:
   minAvailable: 1

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/redis/redis-statefulset.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/redis/redis-statefulset.yaml
@@ -14,6 +14,8 @@ spec:
       {{- include "timesketch.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app.kubernetes.io/component: redis
         {{- include "timesketch.selectorLabels" . | nindent 8 }}

--- a/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: yeti
-version: 2.2.9
+version: 2.3.0
 description: A Helm chart for Yeti Kubernetes deployments.
 keywords:
 - yeti

--- a/charts/osdfir-infrastructure/charts/yeti/templates/arangodb/arangodb-pdb.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/arangodb/arangodb-pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: yeti-arangodb-pdb
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: arangodb
+      app.kubernetes.io/name: yeti

--- a/charts/osdfir-infrastructure/charts/yeti/templates/arangodb/arangodb-pdb.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/arangodb/arangodb-pdb.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: yeti-arangodb-pdb
+  name: {{ .Release.Name }}-yeti-arangodb-pdb
   namespace: {{ .Release.Namespace | quote }}
 spec:
   minAvailable: 1

--- a/charts/osdfir-infrastructure/charts/yeti/templates/arangodb/arangodb-statefulset.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/arangodb/arangodb-statefulset.yaml
@@ -14,6 +14,8 @@ spec:
       {{- include "yeti.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app.kubernetes.io/component: arangodb
         {{- include "yeti.selectorLabels" . | nindent 8 }}

--- a/charts/osdfir-infrastructure/charts/yeti/templates/redis/redis-pdb.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/redis/redis-pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: yeti-redis-pdb
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: redis
+      app.kubernetes.io/name: yeti

--- a/charts/osdfir-infrastructure/charts/yeti/templates/redis/redis-pdb.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/redis/redis-pdb.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: yeti-redis-pdb
+  name: {{ .Release.Name }}-yeti-redis-pdb
   namespace: {{ .Release.Namespace | quote }}
 spec:
   minAvailable: 1

--- a/charts/osdfir-infrastructure/charts/yeti/templates/redis/redis-statefulset.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/redis/redis-statefulset.yaml
@@ -14,6 +14,8 @@ spec:
       {{- include "yeti.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app.kubernetes.io/component: redis
         {{- include "yeti.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
…res pods

<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

To prevent automated maintence from clusters such as GKE Autopilot to disrupt these backend critical pods add the following:
  * Pod Disruption Budget: In this case tells the cluster that there should always be a minimum of 1 of these Pods running at all times
  * Annotation `safe-to-evict: false`: : Prevents the autoscaler from evicting the pod. The Cluster Autoscaler will refuse to scale down or remove any node running a pod with this annotation for up to 7 days. (in general makes eviction less common) See [ref](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/extended-duration-pods) for more info

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Newly added variables are documented in the values.yaml
- [X] Title of the pull request is descriptive
