### PR TITLE
fix: dynamically resolve gunicorn.conf.py path in timesketch

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: timesketch
   repository: file://charts/timesketch
-  version: 2.5.3
+  version: 2.5.4
 - name: yeti
   repository: file://charts/yeti
   version: 2.3.0
@@ -14,5 +14,5 @@ dependencies:
 - name: hashr
   repository: file://charts/hashr
   version: 2.0.1
-digest: sha256:6462892ff8dffe9847d8edf07d45551bd242327cd5c4dc9effeb1770d32c0a5b
-generated: "2026-06-10T10:23:46.583195-07:00"
+digest: sha256:1583a6fb571a24aaf57df0b845c9af300ed2fec544378f3c5c7b9164467a2088
+generated: "2026-06-11T18:00:25.064956672Z"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.9.1
+version: 2.9.2
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch
@@ -14,7 +14,7 @@ dependencies:
 - condition: global.timesketch.enabled
   name: timesketch
   repository: file://charts/timesketch
-  version: 2.5.3
+  version: 2.5.4
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti

--- a/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 2.5.3
+version: 2.5.4
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment-v3.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment-v3.yaml
@@ -36,7 +36,7 @@ spec:
         - name: frontend-v3
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/bin/sh", "-c", "exec gunicorn --bind 0.0.0.0:5000 -c /opt/venv/lib/python3.12/site-packages/timesketch/gunicorn.conf.py --capture-output --log-level {{ .Values.config.logLevel }} --timeout {{ .Values.config.wsgiTimeout }} --workers {{ .Values.config.wsgiWorkers }} --limit-request-line {{ .Values.config.wsgiLimitRequestLine }} --max-requests 1000 --max-requests-jitter 100 timesketch.wsgi:application"]
+          command: ["/bin/sh", "-c", "exec gunicorn --bind 0.0.0.0:5000 -c $(python3 -c \"import os, timesketch; print(os.path.join(os.path.dirname(timesketch.__file__), 'gunicorn.conf.py'))\") --capture-output --log-level {{ .Values.config.logLevel }} --timeout {{ .Values.config.wsgiTimeout }} --workers {{ .Values.config.wsgiWorkers }} --limit-request-line {{ .Values.config.wsgiLimitRequestLine }} --max-requests 1000 --max-requests-jitter 100 timesketch.wsgi:application"]
           env:
             - name: TIMESKETCH_UI_MODE
               value: "v3"

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/web-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - name: frontend
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/bin/sh", "-c", "exec gunicorn --bind 0.0.0.0:5000 -c /opt/venv/lib/python3.12/site-packages/timesketch/gunicorn.conf.py --capture-output --log-level {{ .Values.config.logLevel }} --timeout {{ .Values.config.wsgiTimeout }} --workers {{ .Values.config.wsgiWorkers }} --limit-request-line {{ .Values.config.wsgiLimitRequestLine }} --max-requests 1000 --max-requests-jitter 100 timesketch.wsgi:application"]
+          command: ["/bin/sh", "-c", "exec gunicorn --bind 0.0.0.0:5000 -c $(python3 -c \"import os, timesketch; print(os.path.join(os.path.dirname(timesketch.__file__), 'gunicorn.conf.py'))\") --capture-output --log-level {{ .Values.config.logLevel }} --timeout {{ .Values.config.wsgiTimeout }} --workers {{ .Values.config.wsgiWorkers }} --limit-request-line {{ .Values.config.wsgiLimitRequestLine }} --max-requests 1000 --max-requests-jitter 100 timesketch.wsgi:application"]
           {{- if and (not .Release.IsUpgrade) .Values.config.createUser }}
           lifecycle:
             postStart:


### PR DESCRIPTION
This avoids hardcoding the Python version (e.g. python3.12) in the gunicorn command, which breaks when the base image upgrades the Python version.