### PR TITLE
charts/* Increase GCP backend threshold to 4 to better handle GKE control plane blips

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: timesketch
   repository: file://charts/timesketch
-  version: 2.5.4
+  version: 2.5.5
 - name: yeti
   repository: file://charts/yeti
-  version: 2.3.0
+  version: 2.3.1
 - name: openrelik
   repository: file://charts/openrelik
-  version: 2.4.1
+  version: 2.4.2
 - name: grr
   repository: file://charts/grr
   version: 2.3.1
 - name: hashr
   repository: file://charts/hashr
   version: 2.0.1
-digest: sha256:1583a6fb571a24aaf57df0b845c9af300ed2fec544378f3c5c7b9164467a2088
-generated: "2026-06-11T18:00:25.064956672Z"
+digest: sha256:3a5f63508881b5ae28c723df8a35fb7ee6c599d3dc5faac663111214f29a6a49
+generated: "2026-06-24T09:51:23.237057-07:00"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.9.2
+version: 2.9.3
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch
@@ -14,15 +14,15 @@ dependencies:
 - condition: global.timesketch.enabled
   name: timesketch
   repository: file://charts/timesketch
-  version: 2.5.4
+  version: 2.5.5
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti
-  version: 2.3.0
+  version: 2.3.1
 - condition: global.openrelik.enabled
   name: openrelik
   repository: file://charts/openrelik
-  version: 2.4.1
+  version: 2.4.2
 - condition: global.grr.enabled
   name: grr
   repository: file://charts/grr

--- a/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: openrelik
-version: 2.4.1
+version: 2.4.2
 description: A Helm chart for Openrelik Kubernetes deployments.
 keywords:
 - openrelik

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/api-backendconfig.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/api-backendconfig.yaml
@@ -16,7 +16,7 @@ spec:
     checkIntervalSec: 60
     timeoutSec: 5
     healthyThreshold: 2
-    unhealthyThreshold: 2
+    unhealthyThreshold: 4
     type: HTTP
     requestPath: /openapi.json
     port: 8710

--- a/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/frontend-backendconfig.yaml
+++ b/charts/osdfir-infrastructure/charts/openrelik/templates/gcp/frontend-backendconfig.yaml
@@ -16,7 +16,7 @@ spec:
     checkIntervalSec: 300
     timeoutSec: 5
     healthyThreshold: 2
-    unhealthyThreshold: 2
+    unhealthyThreshold: 4
     type: HTTP
     requestPath: /
     port: 8711

--- a/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 2.5.4
+version: 2.5.5
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/gcp/backendconfig.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/gcp/backendconfig.yaml
@@ -10,7 +10,7 @@ spec:
     checkIntervalSec: 5
     timeoutSec: 5
     healthyThreshold: 2
-    unhealthyThreshold: 2
+    unhealthyThreshold: 4
     type: HTTP
     requestPath: /healthz/
     port: 8080

--- a/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: yeti
-version: 2.3.0
+version: 2.3.1
 description: A Helm chart for Yeti Kubernetes deployments.
 keywords:
 - yeti

--- a/charts/osdfir-infrastructure/charts/yeti/templates/gcp/backendconfig.yaml
+++ b/charts/osdfir-infrastructure/charts/yeti/templates/gcp/backendconfig.yaml
@@ -10,7 +10,7 @@ spec:
     checkIntervalSec: 5
     timeoutSec: 5
     healthyThreshold: 2
-    unhealthyThreshold: 2
+    unhealthyThreshold: 4
     type: HTTP
     requestPath: /login/
     port: 9000


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please have an issue created and ready to be linked to the PR. 
 -->

### Description of the change

<!-- Describe what the change does. -->

In situations where the GKE control plane is down (due to an upgrade or transient issue), increase the unhealthy threshold for all GCP backend configs to stay more resilient when this happens. 

The goal of increasing the threshold isn't to fix the Control Plane disruption itself (which is an Autopilot-managed event), but to prevent the Load Balancer from overreacting to a transient management blip. It keeps the network connections open for longer while the control plane is rebooting.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Newly added variables are documented in the values.yaml
- [X] Title of the pull request is descriptive
