### PR TITLE
Add configurable robust proxy buffering configurations for Timesketch Nginx

### DIFF
--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: timesketch
   repository: file://charts/timesketch
-  version: 2.5.5
+  version: 2.5.6
 - name: yeti
   repository: file://charts/yeti
   version: 2.3.1
@@ -14,5 +14,5 @@ dependencies:
 - name: hashr
   repository: file://charts/hashr
   version: 2.0.1
-digest: sha256:3a5f63508881b5ae28c723df8a35fb7ee6c599d3dc5faac663111214f29a6a49
-generated: "2026-06-24T09:51:23.237057-07:00"
+digest: sha256:70b737315ff9b53feb39036781ae8206ca3e4d75b4020c9415ac7e79aaa6488b
+generated: "2026-07-06T16:17:46.000000-07:00"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.9.3
+version: 2.9.4
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch
@@ -14,7 +14,7 @@ dependencies:
 - condition: global.timesketch.enabled
   name: timesketch
   repository: file://charts/timesketch
-  version: 2.5.5
+  version: 2.5.6
 - condition: global.yeti.enabled
   name: yeti
   repository: file://charts/yeti

--- a/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: timesketch
-version: 2.5.5
+version: 2.5.6
 description: A Helm chart for Timesketch Kubernetes deployments.
 keywords:
 - timesketch

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/nginx/nginx-configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/nginx/nginx-configmap.yaml
@@ -12,11 +12,17 @@ data:
         listen [::]:8080;
         client_max_body_size 0m;
         location / {
-            proxy_buffer_size 128k;
-            proxy_buffers 4 256k;
-            proxy_busy_buffers_size 256k;
-            proxy_pass http://{{ .Release.Name }}-timesketch:5000/;
+            # --- Robust Memory Buffering Configurations ---
+            proxy_buffering {{ .Values.nginx.proxyBuffering | default "on" }};
+            proxy_buffer_size {{ .Values.nginx.proxyBufferSize | default "128k" }};
+            proxy_buffers {{ .Values.nginx.proxyBuffers | default "4 256k" }};
+            proxy_busy_buffers_size {{ .Values.nginx.proxyBusyBuffersSize | default "256k" }};
+
+            # Safety gate to prevent GKE Ephemeral-Storage pod eviction (DiskPressure)
+            proxy_max_temp_file_size {{ .Values.nginx.proxyMaxTempFileSize | default "512M" }};
+
             proxy_read_timeout {{ .Values.config.nginxReadTimeout }}s;
+            proxy_pass http://{{ .Release.Name }}-timesketch:5000/;
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -33,11 +39,17 @@ data:
             return 200;
         }
         location /v3 {
-            proxy_buffer_size 128k;
-            proxy_buffers 4 256k;
-            proxy_busy_buffers_size 256k;
-            proxy_pass http://{{ .Release.Name }}-timesketch-v3:5000/;
+            # --- Robust Memory Buffering Configurations ---
+            proxy_buffering {{ .Values.nginx.proxyBuffering | default "on" }};
+            proxy_buffer_size {{ .Values.nginx.proxyBufferSize | default "128k" }};
+            proxy_buffers {{ .Values.nginx.proxyBuffers | default "4 256k" }};
+            proxy_busy_buffers_size {{ .Values.nginx.proxyBusyBuffersSize | default "256k" }};
+
+            # Safety gate to prevent GKE Ephemeral-Storage pod eviction (DiskPressure)
+            proxy_max_temp_file_size {{ .Values.nginx.proxyMaxTempFileSize | default "512M" }};
+
             proxy_read_timeout {{ .Values.config.nginxReadTimeout }}s;
+            proxy_pass http://{{ .Release.Name }}-timesketch-v3:5000/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/charts/osdfir-infrastructure/charts/timesketch/templates/nginx/nginx-configmap.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/templates/nginx/nginx-configmap.yaml
@@ -13,13 +13,13 @@ data:
         client_max_body_size 0m;
         location / {
             # --- Robust Memory Buffering Configurations ---
-            proxy_buffering {{ .Values.nginx.proxyBuffering | default "on" }};
-            proxy_buffer_size {{ .Values.nginx.proxyBufferSize | default "128k" }};
-            proxy_buffers {{ .Values.nginx.proxyBuffers | default "4 256k" }};
-            proxy_busy_buffers_size {{ .Values.nginx.proxyBusyBuffersSize | default "256k" }};
+            proxy_buffering {{ .Values.nginx.config.proxyBuffering | default "on" }};
+            proxy_buffer_size {{ .Values.nginx.config.proxyBufferSize | default "128k" }};
+            proxy_buffers {{ .Values.nginx.config.proxyBuffers | default "4 256k" }};
+            proxy_busy_buffers_size {{ .Values.nginx.config.proxyBusyBuffersSize | default "256k" }};
 
             # Safety gate to prevent GKE Ephemeral-Storage pod eviction (DiskPressure)
-            proxy_max_temp_file_size {{ .Values.nginx.proxyMaxTempFileSize | default "512M" }};
+            proxy_max_temp_file_size {{ .Values.nginx.config.proxyMaxTempFileSize | default "512M" }};
 
             proxy_read_timeout {{ .Values.config.nginxReadTimeout }}s;
             proxy_pass http://{{ .Release.Name }}-timesketch:5000/;
@@ -40,13 +40,13 @@ data:
         }
         location /v3 {
             # --- Robust Memory Buffering Configurations ---
-            proxy_buffering {{ .Values.nginx.proxyBuffering | default "on" }};
-            proxy_buffer_size {{ .Values.nginx.proxyBufferSize | default "128k" }};
-            proxy_buffers {{ .Values.nginx.proxyBuffers | default "4 256k" }};
-            proxy_busy_buffers_size {{ .Values.nginx.proxyBusyBuffersSize | default "256k" }};
+            proxy_buffering {{ .Values.nginx.config.proxyBuffering | default "on" }};
+            proxy_buffer_size {{ .Values.nginx.config.proxyBufferSize | default "128k" }};
+            proxy_buffers {{ .Values.nginx.config.proxyBuffers | default "4 256k" }};
+            proxy_busy_buffers_size {{ .Values.nginx.config.proxyBusyBuffersSize | default "256k" }};
 
             # Safety gate to prevent GKE Ephemeral-Storage pod eviction (DiskPressure)
-            proxy_max_temp_file_size {{ .Values.nginx.proxyMaxTempFileSize | default "512M" }};
+            proxy_max_temp_file_size {{ .Values.nginx.config.proxyMaxTempFileSize | default "512M" }};
 
             proxy_read_timeout {{ .Values.config.nginxReadTimeout }}s;
             proxy_pass http://{{ .Release.Name }}-timesketch-v3:5000/;

--- a/charts/osdfir-infrastructure/charts/timesketch/values.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/values.yaml
@@ -79,10 +79,10 @@ config:
   wsgiLimitRequestLine: 8190
   ## @param config.wsgiTimeout Number of seconds before the Gunicorn worker times out
   ##
-  wsgiTimeout: 600
+  wsgiTimeout: 300
   ## @param config.nginxTimeout Number of seconds before Nginx times out on a read operation
   ##
-  nginxReadTimeout: 600
+  nginxReadTimeout: 300
   ## @param config.enableServiceAccount Add the K8s service account `timesketch` to all Timesketch deployment manifests
   ## This is useful when associationg additional cloud provider permissions with Timesketch pods (e.g. GCP trace explorer).
   ##
@@ -229,6 +229,23 @@ nginx:
   ## @param nginx.nodeSelector Node labels for Timesketch nginx pods assignment
   ##
   nodeSelector: {}
+  ## Timesketch Nginx proxy buffering configurations
+  ##
+  ## @param nginx.proxyBuffering Enable proxy buffering for Timesketch paths
+  ##
+  proxyBuffering: "on"
+  ## @param nginx.proxyBufferSize Buffer size for proxying Timesketch responses
+  ##
+  proxyBufferSize: "128k"
+  ## @param nginx.proxyBuffers Number and size of buffers for proxying Timesketch responses
+  ##
+  proxyBuffers: "4 256k"
+  ## @param nginx.proxyBusyBuffersSize Busy buffers size for proxying Timesketch responses
+  ##
+  proxyBusyBuffersSize: "256k"
+  ## @param nginx.proxyMaxTempFileSize Maximum size of temporary files for proxying Timesketch responses
+  ##
+  proxyMaxTempFileSize: "512M"
 ## Persistence Storage Parameters
 ##
 persistence:

--- a/charts/osdfir-infrastructure/charts/timesketch/values.yaml
+++ b/charts/osdfir-infrastructure/charts/timesketch/values.yaml
@@ -229,23 +229,26 @@ nginx:
   ## @param nginx.nodeSelector Node labels for Timesketch nginx pods assignment
   ##
   nodeSelector: {}
-  ## Timesketch Nginx proxy buffering configurations
+  ## Timesketch Nginx config block
   ##
-  ## @param nginx.proxyBuffering Enable proxy buffering for Timesketch paths
-  ##
-  proxyBuffering: "on"
-  ## @param nginx.proxyBufferSize Buffer size for proxying Timesketch responses
-  ##
-  proxyBufferSize: "128k"
-  ## @param nginx.proxyBuffers Number and size of buffers for proxying Timesketch responses
-  ##
-  proxyBuffers: "4 256k"
-  ## @param nginx.proxyBusyBuffersSize Busy buffers size for proxying Timesketch responses
-  ##
-  proxyBusyBuffersSize: "256k"
-  ## @param nginx.proxyMaxTempFileSize Maximum size of temporary files for proxying Timesketch responses
-  ##
-  proxyMaxTempFileSize: "512M"
+  config:
+    ## Timesketch Nginx proxy buffering configurations
+    ##
+    ## @param nginx.config.proxyBuffering Enable proxy buffering for Timesketch paths
+    ##
+    proxyBuffering: "on"
+    ## @param nginx.config.proxyBufferSize Buffer size for proxying Timesketch responses
+    ##
+    proxyBufferSize: "128k"
+    ## @param nginx.config.proxyBuffers Number and size of buffers for proxying Timesketch responses
+    ##
+    proxyBuffers: "4 256k"
+    ## @param nginx.config.proxyBusyBuffersSize Busy buffers size for proxying Timesketch responses
+    ##
+    proxyBusyBuffersSize: "256k"
+    ## @param nginx.config.proxyMaxTempFileSize Maximum size of temporary files for proxying Timesketch responses
+    ##
+    proxyMaxTempFileSize: "512M"
 ## Persistence Storage Parameters
 ##
 persistence:


### PR DESCRIPTION
Adapts the Timesketch Nginx template to support configurable memory buffering settings. This mitigates potential GKE Ephemeral-Storage pod eviction issues (DiskPressure) by capping disk buffering and optimizes payload transport.

### Changes
- **Timesketch Nginx Template (`nginx-configmap.yaml`)**:
  - Configured proxy buffering settings (`proxy_buffering`, `proxy_buffer_size`, `proxy_buffers`, `proxy_busy_buffers_size`) on all Timesketch paths (`/` and `/v3`).
  - Added a `proxy_max_temp_file_size` limit to prevent excessive disk buffering and GKE pod evictions.
- **Chart configurations (`values.yaml`)**:
  - Exposed the new variables under the `nginx` configuration block for easy overrides, keeping the default fallback values aligned with the existing baseline.