### PR TITLE
feat(grr): rebuild external client installers

### DIFF
--- a/.github/scripts/test-grr-client-builder.sh
+++ b/.github/scripts/test-grr-client-builder.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart="charts/osdfir-infrastructure/charts/grr"
+helm="${HELM:-helm}"
+
+default_render="$("$helm" template test "$chart")"
+grep -Fq -- "--build-arg=FLEETSPEAK_FRONTEND=10.0.0.2" <<<"$default_render"
+grep -Fq -- "--build-arg=FLEETSPEAK_FRONTEND_PORT=30443" <<<"$default_render"
+grep -Fq "Waiting for the external Fleetspeak endpoint to serve the current certificate" <<<"$default_render"
+
+external_render="$("$helm" template test "$chart" \
+  --set clientBuilder.address=external.example.test \
+  --set-string clientBuilder.port=443 \
+  --set-string clientBuilder.trustedCert=test-cert)"
+grep -Fq -- "--build-arg=FLEETSPEAK_FRONTEND=external.example.test" <<<"$external_render"
+grep -Fq -- "--build-arg=FLEETSPEAK_FRONTEND_PORT=443" <<<"$external_render"
+grep -Fq -- "--build-arg=FLEETSPEAK_TRUSTED_CERT_B64=dGVzdC1jZXJ0" <<<"$external_render"
+if grep -Fq "Waiting for the external Fleetspeak endpoint to serve the current certificate" <<<"$external_render"; then
+  exit 1
+fi
+
+certificate="$(
+  awk '/^  tls.crt: / { print $2; exit }' <<<"$external_render" |
+    openssl base64 -d -A
+)"
+grep -Fq "DNS:external.example.test" <<<"$(openssl x509 -noout -text <<<"$certificate")"
+
+job_name="$(
+  awk '/^  name: test-grr-client-builder-/ { print $2; exit }' <<<"$external_render"
+)"
+changed_job_name="$(
+  "$helm" template test "$chart" \
+    --set clientBuilder.address=external.example.test \
+    --set-string clientBuilder.port=8443 \
+    --set-string clientBuilder.trustedCert=test-cert |
+    awk '/^  name: test-grr-client-builder-/ { print $2; exit }'
+)"
+test "$job_name" != "$changed_job_name"
+
+provided_cert_render="$("$helm" template test "$chart" \
+  --set fleetspeak.generateCert=false \
+  --set-string fleetspeak.frontend.cert=test-cert \
+  --set-string fleetspeak.frontend.key=test-key)"
+grep -Fq "tls.crt: dGVzdC1jZXJ0" <<<"$provided_cert_render"
+grep -Fq "tls.key: dGVzdC1rZXk=" <<<"$provided_cert_render"

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -2,6 +2,9 @@ name: Lint and Test Charts
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -34,6 +34,10 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Test GRR client builder rendering
+        if: steps.list-changed.outputs.changed == 'true'
+        run: .github/scripts/test-grr-client-builder.sh
+
       - name: Run chart-testing (lint main osdfir chart)
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --config .github/ct-main.yaml

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,22 +7,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
           version: v3.12.1
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.9'
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2
         with:
           version: v3.8.0
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1.7.0
+        uses: helm/kind-action@fa81e57adff234b2908110485695db0f181f3c67 # v1.7.0
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/osdfir-infrastructure/Chart.lock
+++ b/charts/osdfir-infrastructure/Chart.lock
@@ -10,9 +10,9 @@ dependencies:
   version: 2.4.2
 - name: grr
   repository: file://charts/grr
-  version: 2.3.1
+  version: 2.4.0
 - name: hashr
   repository: file://charts/hashr
   version: 2.0.1
-digest: sha256:70b737315ff9b53feb39036781ae8206ca3e4d75b4020c9415ac7e79aaa6488b
-generated: "2026-07-06T16:17:46.000000-07:00"
+digest: sha256:04415c3bac45be1d72879734dd1564a327c36f374c7497577b4e32a19720185b
+generated: "2026-07-29T22:26:58.538533-07:00"

--- a/charts/osdfir-infrastructure/Chart.yaml
+++ b/charts/osdfir-infrastructure/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: osdfir-infrastructure
-version: 2.9.4
+version: 2.10.0
 description: A Helm chart for Open Source Digital Forensics Kubernetes deployments.
 keywords:
 - timesketch
@@ -26,7 +26,7 @@ dependencies:
 - condition: global.grr.enabled
   name: grr
   repository: file://charts/grr
-  version: 2.3.1
+  version: 2.4.0
 - condition: global.hashr.enabled
   name: hashr
   repository: file://charts/hashr

--- a/charts/osdfir-infrastructure/charts/grr/Chart.yaml
+++ b/charts/osdfir-infrastructure/charts/grr/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: grr
-version: 2.3.1
+version: 2.4.0
 description: A Helm chart for GRR/Fleetspeak Kubernetes deployments.
 keywords:
 - grr

--- a/charts/osdfir-infrastructure/charts/grr/README.md
+++ b/charts/osdfir-infrastructure/charts/grr/README.md
@@ -12,3 +12,123 @@ cd osdfir-infrastructure
 export REPO=$(pwd)
 ```
 
+## Build clients for an external Fleetspeak address
+
+The chart repacks the GRR client templates when it is installed. The resulting
+`.deb`, `.rpm`, and `.msi` installers are uploaded to GRR and are available in
+the Admin UI under **Binaries → executables → installers**.
+
+By default, the builder embeds the first Kubernetes node internal IP and
+`fleetspeak.frontend.listenPort` in those installers. For a client outside the
+cluster, set an address and port that the client can reach:
+
+```console
+helm upgrade --install grr \
+  "$REPO/charts/osdfir-infrastructure/charts/grr" \
+  --set clientBuilder.address=grr.example.com \
+  --set-string clientBuilder.port=30443
+```
+
+When installing the unified OSDFIR Infrastructure chart, prefix these settings
+with the subchart name:
+
+```console
+helm upgrade --install osdfir "$REPO/charts/osdfir-infrastructure" \
+  --set grr.clientBuilder.address=grr.example.com \
+  --set-string grr.clientBuilder.port=30443
+```
+
+The default self-signed Fleetspeak certificate includes the configured client
+address. Changing the client address or port rotates that certificate, restarts
+the Fleetspeak frontend, and creates a client-builder Job with a new name. This
+allows `helm upgrade` to repack the installers without attempting to patch the
+immutable pod template of the previous Job.
+
+The builder retrieves the certificate from the external endpoint by default.
+If that endpoint is not reachable from the cluster, or TLS terminates at a
+proxy, provide the certificate that clients should trust:
+
+```console
+helm upgrade --install grr \
+  "$REPO/charts/osdfir-infrastructure/charts/grr" \
+  --set clientBuilder.address=grr.example.com \
+  --set-string clientBuilder.port=443 \
+  --set-file clientBuilder.trustedCert=./fleetspeak-frontend.crt
+```
+
+To configure the Fleetspeak frontend with an existing certificate instead of a
+self-signed one, provide both the certificate and private key:
+
+```console
+helm upgrade --install grr \
+  "$REPO/charts/osdfir-infrastructure/charts/grr" \
+  --set fleetspeak.generateCert=false \
+  --set-file fleetspeak.frontend.cert=./fleetspeak-frontend.crt \
+  --set-file fleetspeak.frontend.key=./fleetspeak-frontend.key \
+  --set-file clientBuilder.trustedCert=./fleetspeak-frontend.crt
+```
+
+### Validate with KIND
+
+Expose the default Fleetspeak NodePort when creating a disposable KIND cluster:
+
+```yaml
+# kind.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30443
+        hostPort: 30443
+        protocol: TCP
+```
+
+```console
+kind create cluster --name grr-client-test --config kind.yaml
+```
+
+Choose an address that is reachable both from the target client and, when
+certificate discovery is used, from the cluster. Install the chart with that
+address:
+
+```console
+export FLEETSPEAK_ADDRESS=<externally-reachable-address>
+
+helm upgrade --install grr \
+  "$REPO/charts/osdfir-infrastructure/charts/grr" \
+  --set clientBuilder.address="$FLEETSPEAK_ADDRESS" \
+  --set-string clientBuilder.port=30443 \
+  --wait
+```
+
+Verify TLS reachability before waiting for the client build:
+
+```console
+openssl s_client \
+  -connect "$FLEETSPEAK_ADDRESS:30443" \
+  -servername "$FLEETSPEAK_ADDRESS" </dev/null
+```
+
+Wait for the current builder Job and inspect its logs:
+
+```console
+kubectl wait --for=condition=complete \
+  job -l app.kubernetes.io/component=client-builder \
+  --timeout=20m
+
+kubectl logs \
+  job/$(kubectl get job \
+    -l app.kubernetes.io/component=client-builder \
+    -o jsonpath='{.items[0].metadata.name}')
+```
+
+Open the GRR Admin UI and download an installer:
+
+```console
+kubectl port-forward service/grr-grr-admin 8000:8000
+```
+
+After installing it on a test machine, confirm the new client appears in GRR
+and that its Fleetspeak connection targets the configured external address and
+port.

--- a/charts/osdfir-infrastructure/charts/grr/containers/grr-client/Dockerfile.kaniko
+++ b/charts/osdfir-infrastructure/charts/grr/containers/grr-client/Dockerfile.kaniko
@@ -15,6 +15,7 @@ FROM ghcr.io/google/grr:v3.4.9.1-release AS grr
 
 ARG FLEETSPEAK_FRONTEND
 ARG FLEETSPEAK_FRONTEND_PORT
+ARG FLEETSPEAK_TRUSTED_CERT_B64
 
 WORKDIR /
 
@@ -23,7 +24,12 @@ COPY grr-client-config.yaml /config/grr.client.yaml
 
 RUN echo "FLEETSPEAK_FRONTEND: $FLEETSPEAK_FRONTEND, FLEETSPEAK_FRONTEND_PORT: $FLEETSPEAK_FRONTEND_PORT";
 
-RUN export FLEETSPEAK_CERT=$(openssl s_client -showcerts -nocommands -connect $FLEETSPEAK_FRONTEND:$FLEETSPEAK_FRONTEND_PORT< /dev/null | openssl x509 -outform pem | sed ':a;N;$!ba;s/\n/\\\\n/g') && \
+RUN if [ -n "$FLEETSPEAK_TRUSTED_CERT_B64" ]; then \
+      printf '%s' "$FLEETSPEAK_TRUSTED_CERT_B64" | base64 -d > /tmp/fleetspeak.crt; \
+    else \
+      openssl s_client -showcerts -nocommands -servername "$FLEETSPEAK_FRONTEND" -connect "$FLEETSPEAK_FRONTEND:$FLEETSPEAK_FRONTEND_PORT" < /dev/null | openssl x509 -outform pem > /tmp/fleetspeak.crt; \
+    fi && \
+    export FLEETSPEAK_CERT=$(sed ':a;N;$!ba;s/\n/\\\\n/g' /tmp/fleetspeak.crt) && \
     sed "s'FLEETSPEAK_FRONTEND_ADDRESS'$FLEETSPEAK_FRONTEND'g" /config/config.textproto.tmpl > /config/config.textproto && \
     sed -i "s'FLEETSPEAK_FRONTEND_PORT'$FLEETSPEAK_FRONTEND_PORT'" /config/config.textproto && \
     sed -i "s'FRONTEND_TRUSTED_CERTIFICATES'\"$FLEETSPEAK_CERT\"'g" /config/config.textproto && \

--- a/charts/osdfir-infrastructure/charts/grr/templates/_helpers.tpl
+++ b/charts/osdfir-infrastructure/charts/grr/templates/_helpers.tpl
@@ -60,3 +60,51 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve the address embedded in Fleetspeak client installers.
+*/}}
+{{- define "grr.clientBuilderAddress" -}}
+{{- $clientBuilder := .Values.clientBuilder | default dict -}}
+{{- $address := get $clientBuilder "address" | default "" -}}
+{{- if $address -}}
+{{- $address -}}
+{{- else if or (eq .Values.fleetspeak.frontend.expose "internal") (eq .Values.fleetspeak.frontend.expose "external") -}}
+{{- default "10.0.0.2" .Values.fleetspeak.frontend.address -}}
+{{- else -}}
+{{- $frontend := "" -}}
+{{- $lookupResult := lookup "v1" "Node" "" "" | default dict -}}
+{{- range (get $lookupResult "items" | default list) -}}
+{{- range (get (get . "status" | default dict) "addresses" | default list) -}}
+{{- if and (not $frontend) (eq (get . "type") "InternalIP") -}}
+{{- $frontend = get . "address" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- default "10.0.0.2" $frontend -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolve the port embedded in Fleetspeak client installers.
+*/}}
+{{- define "grr.clientBuilderPort" -}}
+{{- $clientBuilder := .Values.clientBuilder | default dict -}}
+{{- default .Values.fleetspeak.frontend.listenPort (get $clientBuilder "port") -}}
+{{- end }}
+
+{{/*
+Hash the inputs that determine the Fleetspeak frontend certificate.
+*/}}
+{{- define "grr.fleetspeakCertificateHash" -}}
+{{- $frontend := .Values.fleetspeak.frontend | default dict -}}
+{{- printf "%v|%s|%s|%s|%s|%s" .Values.fleetspeak.generateCert .Values.fleetspeak.subjectCommonName (include "grr.clientBuilderAddress" .) (include "grr.clientBuilderPort" .) (get $frontend "cert" | default "") (get $frontend "key" | default "") | sha256sum -}}
+{{- end }}
+
+{{/*
+Hash the inputs that determine a GRR client build.
+*/}}
+{{- define "grr.clientBuilderHash" -}}
+{{- $clientBuilder := .Values.clientBuilder | default dict -}}
+{{- printf "%s|%s|%s|%s|%s|%s|%s|%s" (include "grr.fleetspeakCertificateHash" .) (get $clientBuilder "trustedCert" | default "") .Values.grr.version (.Values.grr.daemon.image | default "") .Values.initContainer.image .Values.initContainer.kanikoImage .Chart.Version .Release.Name | sha256sum -}}
+{{- end }}

--- a/charts/osdfir-infrastructure/charts/grr/templates/fleetspeak/fleetspeak-frontend-components-secret.yaml
+++ b/charts/osdfir-infrastructure/charts/grr/templates/fleetspeak/fleetspeak-frontend-components-secret.yaml
@@ -1,52 +1,47 @@
-{{- /* Step 1: Perform lookup, store result */}}
-{{- $lookupResult := lookup "v1" "Node" "" "" | default dict -}}
-{{- $internalIP := "" -}}
-{{- /* Step 2: Get values, store result */}}
-{{- $nodeList := $lookupResult.items -}}
-{{- if $nodeList }}
-  {{- /* Step 3: Get first node data, store result */}}
-  {{- $nodeData := first $nodeList -}}
-  {{- /* Step 4: Get the status */}}
-  {{- $statusValue := $nodeData.status -}}
-  {{- /* Step 5: Get the addresses */}}
-  {{- $addressesList := $statusValue.addresses -}}
-  {{- /* Step 6: Get the InternalIP address */}}
-  {{- range $address := $addressesList -}}
-    {{- if and (not $internalIP) (eq $address.type "InternalIP") -}}
-      {{- $internalIP = $address.address -}}
-    {{- end -}}
-  {{- end -}}
+{{- $address := include "grr.clientBuilderAddress" . -}}
+{{- $certIPs := list -}}
+{{- $certDNSNames := list "fleetspeak-frontend" -}}
+{{- if or (regexMatch "^[0-9.]+$" $address) (contains ":" $address) -}}
+  {{- $certIPs = append $certIPs $address -}}
+{{- else -}}
+  {{- $certDNSNames = append $certDNSNames $address -}}
 {{- end -}}
-{{- $cert := "" -}}
-{{- if or (eq .Values.fleetspeak.frontend.expose "internal") (eq .Values.fleetspeak.frontend.expose "external") -}}
-  {{- $cert = genSelfSignedCert .Values.fleetspeak.subjectCommonName (list .Values.fleetspeak.frontend.address) (list "fleetspeak-frontend")  3650 }}
-{{- else }}
-  {{- if not $internalIP -}}
-    {{- /* Note: This should not ever happen but we set it to keep the linter happy. */}}
-    {{- $cert = genSelfSignedCert .Values.fleetspeak.subjectCommonName (list "10.0.0.2") (list "fleetspeak-frontend")  3650 }}
-  {{- else -}}
-  {{- $cert = genSelfSignedCert .Values.fleetspeak.subjectCommonName (list $internalIP) (list "fleetspeak-frontend")  3650 }}
-  {{- end -}}
+{{- $certHash := include "grr.fleetspeakCertificateHash" . -}}
+{{- $frontend := .Values.fleetspeak.frontend | default dict -}}
+{{- $secretName := printf "%s-grr-fleetspeak-frontend-components" .Release.Name -}}
+{{- $namespace := default .Release.Namespace .Values.grr.namespace -}}
+{{- $existingSecret := lookup "v1" "Secret" $namespace $secretName | default dict -}}
+{{- $metadata := get $existingSecret "metadata" | default dict -}}
+{{- $annotations := get $metadata "annotations" | default dict -}}
+{{- $data := get $existingSecret "data" | default dict -}}
+{{- $reuseCert := and .Values.fleetspeak.generateCert (eq (get $annotations "grr.osdfir.dev/certificate-hash") $certHash) (hasKey $data "tls.crt") (hasKey $data "tls.key") -}}
+{{- $cert := dict -}}
+{{- if $reuseCert -}}
+  {{- $cert = dict "Cert" (get $data "tls.crt" | b64dec) "Key" (get $data "tls.key" | b64dec) -}}
+{{- else if .Values.fleetspeak.generateCert -}}
+  {{- $cert = genSelfSignedCert .Values.fleetspeak.subjectCommonName $certIPs $certDNSNames 3650 -}}
+{{- else -}}
+  {{- $cert = dict "Cert" (required "fleetspeak.frontend.cert is required when fleetspeak.generateCert is false" (get $frontend "cert")) "Key" (required "fleetspeak.frontend.key is required when fleetspeak.generateCert is false" (get $frontend "key")) -}}
 {{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-grr-fleetspeak-frontend-components
+  name: {{ $secretName }}
   {{- if .Values.grr.namespace }}
   namespace: {{ .Values.grr.namespace }}
   {{- end }}
+  annotations:
+    grr.osdfir.dev/certificate-hash: {{ $certHash | quote }}
+data:
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
 stringData:
   frontend.components.textproto: |
     mysql_data_source_name: "{{ .Values.fleetspeak.mysqlDb.userName }}:{{ .Values.fleetspeak.mysqlDb.userPassword }}@tcp({{ .Values.fleetspeak.mysqlDb.address }}:{{ .Values.fleetspeak.mysqlDb.port }})/{{ .Values.fleetspeak.mysqlDb.name }}"
     https_config: <
       listen_address: "0.0.0.0:{{ .Values.fleetspeak.frontend.listenPort }}"
-      {{- if .Values.fleetspeak.generateCert }}
       certificates: {{ $cert.Cert | quote }}
       key: {{ $cert.Key | quote }}
-      {{- else }}
-      certificates: {{ default (.Files.Get "../../certs/fleetspeak-frontend.crt") .Values.fleetspeak.frontend.cert | quote }}
-      key: {{ default (.Files.Get "../../certs/fleetspeak-frontend.key") .Values.fleetspeak.frontend.key | quote }}
-      {{- end }}
       {{- if .Values.fleetspeak.httpsHeaderChecksum }}
       frontend_config: <
         https_header_checksum_config: <

--- a/charts/osdfir-infrastructure/charts/grr/templates/fleetspeak/fleetspeak-frontend-deployment.yaml
+++ b/charts/osdfir-infrastructure/charts/grr/templates/fleetspeak/fleetspeak-frontend-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       app.kubernetes.io/name: fleetspeak-frontend
   template:
     metadata:
+      annotations:
+        grr.osdfir.dev/certificate-hash: {{ include "grr.fleetspeakCertificateHash" . | quote }}
       labels:
         app.kubernetes.io/name: fleetspeak-frontend
         prometheus: fleetspeak-frontend

--- a/charts/osdfir-infrastructure/charts/grr/templates/job-build-grr-client.yaml
+++ b/charts/osdfir-infrastructure/charts/grr/templates/job-build-grr-client.yaml
@@ -1,30 +1,16 @@
-{{- $frontend := "" -}}
-{{- if or (eq .Values.fleetspeak.frontend.expose "internal") (eq .Values.fleetspeak.frontend.expose "external") -}}
-  {{- $frontend = .Values.fleetspeak.frontend.address -}}
-{{- else }}
-  {{- /* Step 1: Perform lookup, store result */}}
-  {{- $lookupResult := lookup "v1" "Node" "" "" | default dict -}}
-  {{- /* Step 2: Get values, store result */}}
-  {{- $nodeList := $lookupResult.items -}}
-  {{- if $nodeList -}}
-    {{- /* Step 3: Get first node data, store result */}}
-    {{- $nodeData := first $nodeList -}}
-    {{- /* Step 4: Get the status */}}
-    {{- $statusValue := $nodeData.status -}}
-    {{- /* Step 5: Get the addresses */}}
-    {{- $addressesList := $statusValue.addresses -}}
-    {{- /* Step 6: Get the InternalIP address */}}
-    {{- range $address := $addressesList -}}
-      {{- if and (not $frontend) (eq $address.type "InternalIP") -}}
-        {{- $frontend = $address.address -}}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
+{{- $frontend := include "grr.clientBuilderAddress" . -}}
+{{- $frontendPort := include "grr.clientBuilderPort" . -}}
+{{- $builderHash := include "grr.clientBuilderHash" . -}}
+{{- $clientBuilder := .Values.clientBuilder | default dict -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-grr-job-client-builder
+  name: {{ printf "%s-grr-client-builder-%s" (.Release.Name | trunc 35 | trimSuffix "-") (trunc 8 $builderHash) }}
+  labels:
+    app.kubernetes.io/name: grr
+    app.kubernetes.io/component: client-builder
+  annotations:
+    grr.osdfir.dev/client-builder-hash: {{ $builderHash | quote }}
 spec:
   template:
     spec:
@@ -54,6 +40,15 @@ spec:
               echo "Extracting public key from certificate..."
               openssl x509 -in /sign/keys/exe-sign.crt -pubkey -noout > /grr/exe/sign/keys/exe-sign-public-key.pem
             fi
+            {{ if not (get $clientBuilder "trustedCert") }}
+            expected_fingerprint="$(openssl x509 -in /fleetspeak/tls.crt -noout -fingerprint -sha256)"
+            until served_fingerprint="$(openssl s_client -connect "{{ $frontend }}:{{ $frontendPort }}" -servername "{{ $frontend }}" < /dev/null 2>/dev/null | openssl x509 -noout -fingerprint -sha256 2>/dev/null)" \
+              && [ "$served_fingerprint" = "$expected_fingerprint" ]
+            do
+              echo "Waiting for the external Fleetspeak endpoint to serve the current certificate"
+              sleep 5
+            done
+            {{ end }}
             cd /kaniko-build; 
             git clone https://github.com/google/osdfir-infrastructure.git
             cd osdfir-infrastructure
@@ -68,6 +63,9 @@ spec:
           - name: grr-server-config
             mountPath: /grr/grr.server.yaml
             subPath: server.local.yaml
+          - name: fleetspeak-frontend-certificate
+            mountPath: /fleetspeak/tls.crt
+            subPath: tls.crt
       containers:
         - name: kaniko
           image: {{ .Values.initContainer.kanikoImage }}
@@ -76,7 +74,8 @@ spec:
             - "--context=dir:///kaniko-build/osdfir-infrastructure"
             - "--context-sub-path=charts/osdfir-infrastructure/charts/grr/containers/grr-client/"
             - "--build-arg=FLEETSPEAK_FRONTEND={{ $frontend }}"
-            - "--build-arg=FLEETSPEAK_FRONTEND_PORT={{ .Values.fleetspeak.frontend.listenPort }}"
+            - "--build-arg=FLEETSPEAK_FRONTEND_PORT={{ $frontendPort }}"
+            - "--build-arg=FLEETSPEAK_TRUSTED_CERT_B64={{ get $clientBuilder "trustedCert" | default "" | b64enc }}"
             {{- if .Values.grr.daemon.image }}
             - "--destination={{ .Values.grr.daemon.image }}"
             {{- else }}
@@ -109,3 +108,9 @@ spec:
             items:
             - key: server.local.yaml
               path: server.local.yaml
+        - name: fleetspeak-frontend-certificate
+          secret:
+            secretName: {{ .Release.Name }}-grr-fleetspeak-frontend-components
+            items:
+            - key: tls.crt
+              path: tls.crt

--- a/charts/osdfir-infrastructure/charts/grr/values.yaml
+++ b/charts/osdfir-infrastructure/charts/grr/values.yaml
@@ -15,6 +15,22 @@ global:
   ##
   generateExeSignCert: true
 
+## @section Client builder parameters
+##
+clientBuilder:
+  ## @param clientBuilder.address Sets the externally reachable Fleetspeak address embedded in GRR client installers.
+  ## When empty, the address is derived from fleetspeak.frontend.address or the first Kubernetes node internal IP.
+  ##
+  address: ""
+  ## @param clientBuilder.port Sets the externally reachable Fleetspeak port embedded in GRR client installers.
+  ## When empty, fleetspeak.frontend.listenPort is used.
+  ##
+  port: ""
+  ## @param clientBuilder.trustedCert Sets the PEM-encoded certificate trusted by generated Fleetspeak clients.
+  ## When empty, the client builder retrieves the certificate from clientBuilder.address and clientBuilder.port.
+  ##
+  trustedCert: ""
+
 ## @section Fleetspeak parameters
 ##
 fleetspeak:
@@ -55,6 +71,12 @@ fleetspeak:
     ## @param fleetspeak.frontend.address Sets the Fleetspeak frontend listen to use in a load balancer.
     ##
     address: ""
+    ## @param fleetspeak.frontend.cert Sets the PEM-encoded Fleetspeak frontend certificate when fleetspeak.generateCert is false.
+    ##
+    cert: ""
+    ## @param fleetspeak.frontend.key Sets the PEM-encoded Fleetspeak frontend private key when fleetspeak.generateCert is false.
+    ##
+    key: ""
     ## @param fleetspeak.frontend.listenPort Sets the Fleetspeak frontend listen port to use.
     ##
     listenPort: 30443


### PR DESCRIPTION
### Description of the change

Add explicit GRR client-builder address, port, and trusted-certificate values for
local and non-GCP deployments. Self-signed Fleetspeak certificates are reused
while their inputs remain unchanged and regenerated when the external
connection settings change. Client-builder Jobs are content-addressed so a
`helm upgrade` creates a new Job instead of patching its immutable pod template.
The builder also waits for the external endpoint to serve the current
certificate before repacking clients.

Document a reproducible KIND validation flow and add Helm rendering regression
coverage for the new value combinations.

### Applicable issues

- fixes #274

### Additional information

Validated with:

- `.github/scripts/test-grr-client-builder.sh`
- `helm lint charts/osdfir-infrastructure/charts/grr`
- `helm lint charts/osdfir-infrastructure`
- A disposable KIND cluster, reproducing the fixed-name Job immutability error
  before this change and verifying successful upgrades, stable certificates for
  unchanged inputs, certificate rotation with the requested external DNS SAN,
  regenerated Job arguments, and completion of both builder init stages

Full installer artifact and GRR Admin UI validation still requires an amd64
Linux environment. The amd64-only GRR base image could not complete its Kaniko
unpack under Apple Silicon/Rosetta, so this PR does not claim that final
platform-specific check. Screenshots are not applicable because this changes
chart behavior and documentation rather than the UI.

### Checklist

- [x] Chart version bumped in OSDFIR Infrastructure `Chart.yaml` and the sub chart
`Chart.yaml` according to [semver](http://semver.org/). This is *not necessary*
when the changes only affect README.md files.
- [x] Run `helm dependency update` to pin updated `Chart.yaml` versions.
- [x] Newly added variables are documented in the values.yaml
- [x] Title of the pull request is descriptive
